### PR TITLE
Add exponential backoff retry logic for API and Discord calls

### DIFF
--- a/modules/notifier.py
+++ b/modules/notifier.py
@@ -4,9 +4,15 @@ from datetime import datetime
 import pytz
 import locale
 from urllib.parse import urlparse
+from modules.retry import with_retry
 
 import logging
 logger = logging.getLogger(__name__)
+
+_DISCORD_RETRYABLE = (
+    requests.exceptions.Timeout,
+    requests.exceptions.ConnectionError,
+)
 
 if LOCALE:
     try:
@@ -120,10 +126,16 @@ def send_discord_message(new_games):
         logger.info(f"Sending Discord message with {len(embeds)} game(s)")
 
         safe_webhook_id = _get_safe_webhook_identifier(DISCORD_WEBHOOK_URL)
-        
-        # Send the request and validate response
-        response = requests.post(DISCORD_WEBHOOK_URL, json=data, timeout=10)
-        
+
+        # Send the request with retry logic for transient network errors
+        response = with_retry(
+            func=lambda: requests.post(DISCORD_WEBHOOK_URL, json=data, timeout=10),
+            max_attempts=2,
+            base_delay=1,
+            retryable_exceptions=_DISCORD_RETRYABLE,
+            description=f"Discord webhook send ({safe_webhook_id})",
+        )
+
         # Validate HTTP response status (200-299 range)
         if 200 <= response.status_code <= 299:
             logger.info(f"Discord message sent successfully (Status: {response.status_code})")
@@ -140,7 +152,7 @@ def send_discord_message(new_games):
     except requests.exceptions.Timeout as e:
         safe_webhook_id = _get_safe_webhook_identifier(DISCORD_WEBHOOK_URL)
         logger.error(
-            f"Discord request timed out after 10 seconds | Webhook identifier: {safe_webhook_id} | Games: {len(new_games)}"
+            f"Discord request timed out (10s per-attempt limit, all attempts exhausted) | Webhook identifier: {safe_webhook_id} | Games: {len(new_games)}"
         )
         raise
     except requests.exceptions.ConnectionError as e:

--- a/modules/retry.py
+++ b/modules/retry.py
@@ -1,0 +1,58 @@
+import time
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def with_retry(func, max_attempts, base_delay, retryable_exceptions, description="operation"):
+    """
+    Execute func with retry logic and exponential backoff.
+
+    Args:
+        func: Callable to execute (no arguments).
+        max_attempts: Maximum number of attempts (including the first).
+        base_delay: Base delay in seconds; on the Nth retry (0-indexed attempt),
+                    the sleep duration is base_delay * 2**attempt.
+                    e.g. base_delay=1 gives delays of 1s, 2s, 4s before retries 1, 2, 3.
+        retryable_exceptions: Tuple of exception types that trigger a retry.
+        description: Human-readable label used in log messages.
+
+    Returns:
+        The return value of func() on success.
+
+    Raises:
+        The last caught exception when all attempts are exhausted.
+    """
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be >= 1")
+    if base_delay < 0:
+        raise ValueError("base_delay must be >= 0")
+    if not retryable_exceptions:
+        raise ValueError("retryable_exceptions must be a non-empty iterable of exception types")
+    last_exception = None
+    for attempt in range(max_attempts):
+        try:
+            return func()
+        except retryable_exceptions as exc:
+            last_exception = exc
+            if attempt < max_attempts - 1:
+                delay = base_delay * (2 ** attempt)
+                logger.warning(
+                    "Attempt %d/%d failed for %s: %s: %s. Retrying in %ss...",
+                    attempt + 1,
+                    max_attempts,
+                    description,
+                    type(exc).__name__,
+                    exc,
+                    delay,
+                )
+                time.sleep(delay)
+            else:
+                logger.error(
+                    "All %d attempt(s) failed for %s: %s: %s",
+                    max_attempts,
+                    description,
+                    type(exc).__name__,
+                    exc,
+                )
+    raise last_exception

--- a/modules/scrapper.py
+++ b/modules/scrapper.py
@@ -1,14 +1,29 @@
 import requests
 from config import EPIC_GAMES_API_URL, EPIC_GAMES_REGION
+from modules.retry import with_retry
 
 import logging
 logger = logging.getLogger(__name__)
 
+_RETRYABLE_ERRORS = (
+    requests.exceptions.Timeout,
+    requests.exceptions.ConnectionError,
+)
+
 def fetch_free_games():
     """Fetch free games from Epic Games API."""
     logger.info(f"Fetching free games from Epic Games API. URI: {EPIC_GAMES_API_URL}")
-    response = requests.get(EPIC_GAMES_API_URL)
-    
+    try:
+        response = with_retry(
+            func=lambda: requests.get(EPIC_GAMES_API_URL, timeout=10),
+            max_attempts=4,
+            base_delay=1,
+            retryable_exceptions=_RETRYABLE_ERRORS,
+            description="Epic Games API fetch",
+        )
+    except _RETRYABLE_ERRORS as e:
+        return []
+
     if response.status_code != 200:
         logger.error(f"Failed to fetch Epic Games API. Status Code: {response.status_code}")
         return []

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,218 @@
+import pytest
+from unittest.mock import patch, MagicMock, call
+import requests
+
+from modules import notifier, scrapper
+from modules.retry import with_retry
+
+
+# ---------------------------------------------------------------------------
+# Tests for with_retry utility
+# ---------------------------------------------------------------------------
+
+class TestWithRetry:
+    def test_returns_result_on_first_success(self):
+        func = MagicMock(return_value="ok")
+        result = with_retry(func, max_attempts=3, base_delay=0,
+                            retryable_exceptions=(ValueError,))
+        assert result == "ok"
+        assert func.call_count == 1
+
+    def test_retries_on_retryable_exception(self):
+        func = MagicMock(side_effect=[ValueError("fail"), "ok"])
+        with patch("modules.retry.time.sleep") as mock_sleep:
+            result = with_retry(func, max_attempts=3, base_delay=1,
+                                retryable_exceptions=(ValueError,))
+        assert result == "ok"
+        assert func.call_count == 2
+        mock_sleep.assert_called_once_with(1)
+
+    def test_uses_exponential_backoff(self):
+        func = MagicMock(side_effect=[ValueError(), ValueError(), "ok"])
+        with patch("modules.retry.time.sleep") as mock_sleep:
+            result = with_retry(func, max_attempts=3, base_delay=1,
+                                retryable_exceptions=(ValueError,))
+        assert result == "ok"
+        assert mock_sleep.call_args_list == [call(1), call(2)]
+
+    def test_raises_after_all_attempts_exhausted(self):
+        func = MagicMock(side_effect=ValueError("persistent"))
+        with patch("modules.retry.time.sleep"):
+            with pytest.raises(ValueError, match="persistent"):
+                with_retry(func, max_attempts=3, base_delay=1,
+                           retryable_exceptions=(ValueError,))
+        assert func.call_count == 3
+
+    def test_does_not_retry_on_non_retryable_exception(self):
+        func = MagicMock(side_effect=RuntimeError("not retryable"))
+        with patch("modules.retry.time.sleep") as mock_sleep:
+            with pytest.raises(RuntimeError):
+                with_retry(func, max_attempts=3, base_delay=1,
+                           retryable_exceptions=(ValueError,))
+        assert func.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_no_sleep_after_last_attempt(self):
+        func = MagicMock(side_effect=ValueError("fail"))
+        with patch("modules.retry.time.sleep") as mock_sleep:
+            with pytest.raises(ValueError):
+                with_retry(func, max_attempts=2, base_delay=1,
+                           retryable_exceptions=(ValueError,))
+        # Only one sleep (before the second attempt); no sleep after the final failure
+        assert mock_sleep.call_count == 1
+
+    def test_single_attempt_does_not_sleep(self):
+        func = MagicMock(side_effect=ValueError("fail"))
+        with patch("modules.retry.time.sleep") as mock_sleep:
+            with pytest.raises(ValueError):
+                with_retry(func, max_attempts=1, base_delay=1,
+                           retryable_exceptions=(ValueError,))
+        mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests for retry in fetch_free_games (scrapper)
+# ---------------------------------------------------------------------------
+
+class TestFetchFreeGamesRetry:
+    def _make_response(self, status_code=200, json_data=None):
+        mock = MagicMock()
+        mock.status_code = status_code
+        mock.json.return_value = json_data or {"data": {"Catalog": {"searchStore": {"elements": []}}}}
+        return mock
+
+    def test_retries_on_timeout_and_succeeds(self):
+        good_response = self._make_response(200)
+        with patch("modules.scrapper.requests.get") as mock_get, \
+             patch("modules.retry.time.sleep"):
+            mock_get.side_effect = [
+                requests.exceptions.Timeout(),
+                good_response,
+            ]
+            games = scrapper.fetch_free_games()
+
+        assert mock_get.call_count == 2
+        assert games == []  # empty elements list → no games
+
+    def test_retries_on_connection_error_and_succeeds(self):
+        good_response = self._make_response(200)
+        with patch("modules.scrapper.requests.get") as mock_get, \
+             patch("modules.retry.time.sleep"):
+            mock_get.side_effect = [
+                requests.exceptions.ConnectionError(),
+                good_response,
+            ]
+            games = scrapper.fetch_free_games()
+
+        assert mock_get.call_count == 2
+
+    def test_returns_empty_after_max_retries_exhausted(self):
+        with patch("modules.scrapper.requests.get") as mock_get, \
+             patch("modules.retry.time.sleep"):
+            mock_get.side_effect = requests.exceptions.Timeout()
+            games = scrapper.fetch_free_games()
+
+        assert games == []
+        assert mock_get.call_count == 4
+
+    def test_max_four_attempts_for_api(self):
+        with patch("modules.scrapper.requests.get") as mock_get, \
+             patch("modules.retry.time.sleep") as mock_sleep:
+            mock_get.side_effect = requests.exceptions.ConnectionError()
+            scrapper.fetch_free_games()
+
+        assert mock_get.call_count == 4
+        # Delays: 1s before attempt 2, 2s before attempt 3, 4s before attempt 4
+        assert mock_sleep.call_args_list == [call(1), call(2), call(4)]
+
+    def test_no_retry_on_non_200_status(self):
+        with patch("modules.scrapper.requests.get") as mock_get, \
+             patch("modules.retry.time.sleep") as mock_sleep:
+            mock_get.return_value = self._make_response(500)
+            games = scrapper.fetch_free_games()
+
+        assert games == []
+        assert mock_get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_adds_timeout_to_api_request(self):
+        good_response = self._make_response(200)
+        with patch("modules.scrapper.requests.get", return_value=good_response) as mock_get:
+            scrapper.fetch_free_games()
+
+        _, kwargs = mock_get.call_args
+        assert kwargs.get("timeout") == 10
+
+
+# ---------------------------------------------------------------------------
+# Tests for retry in send_discord_message (notifier)
+# ---------------------------------------------------------------------------
+
+VALID_WEBHOOK = "https://discord.com/api/webhooks/123456789/token_abc"
+
+
+class TestSendDiscordMessageRetry:
+    def _make_response(self, status_code=204):
+        mock_resp = MagicMock()
+        mock_resp.status_code = status_code
+        mock_resp.text = ""
+        mock_resp.raise_for_status = MagicMock()
+        return mock_resp
+
+    def test_retries_on_timeout_and_succeeds(self, sample_games):
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier.requests.post") as mock_post, \
+             patch("modules.retry.time.sleep"):
+            mock_post.side_effect = [
+                requests.exceptions.Timeout(),
+                self._make_response(204),
+            ]
+            notifier.send_discord_message(sample_games)
+
+        assert mock_post.call_count == 2
+
+    def test_retries_on_connection_error_and_succeeds(self, sample_games):
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier.requests.post") as mock_post, \
+             patch("modules.retry.time.sleep"):
+            mock_post.side_effect = [
+                requests.exceptions.ConnectionError(),
+                self._make_response(204),
+            ]
+            notifier.send_discord_message(sample_games)
+
+        assert mock_post.call_count == 2
+
+    def test_raises_after_max_discord_retries(self, sample_games):
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier.requests.post") as mock_post, \
+             patch("modules.retry.time.sleep"):
+            mock_post.side_effect = requests.exceptions.Timeout()
+            with pytest.raises(requests.exceptions.Timeout):
+                notifier.send_discord_message(sample_games)
+
+        assert mock_post.call_count == 2
+
+    def test_max_two_attempts_for_discord(self, sample_games):
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier.requests.post") as mock_post, \
+             patch("modules.retry.time.sleep") as mock_sleep:
+            mock_post.side_effect = requests.exceptions.ConnectionError()
+            with pytest.raises(requests.exceptions.ConnectionError):
+                notifier.send_discord_message(sample_games)
+
+        assert mock_post.call_count == 2
+        # Only one sleep (1s before the second attempt)
+        assert mock_sleep.call_args_list == [call(1)]
+
+    def test_no_retry_on_http_error_status(self, sample_games):
+        mock_resp = self._make_response(400)
+        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError("400")
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier.requests.post", return_value=mock_resp) as mock_post, \
+             patch("modules.retry.time.sleep") as mock_sleep:
+            with pytest.raises(requests.exceptions.HTTPError):
+                notifier.send_discord_message(sample_games)
+
+        assert mock_post.call_count == 1
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
This pull request introduces a robust retry utility to handle transient network errors in both the Epic Games API fetching and Discord webhook notification logic. The new `with_retry` function implements configurable retry logic with exponential backoff, improving reliability for network requests. Comprehensive tests are added to ensure correct retry behavior and error handling.

**Retry logic and reliability improvements:**

* Added a generic `with_retry` function in `modules/retry.py` that retries a callable on specified exceptions, with exponential backoff and logging. This utility is now used for network requests throughout the codebase.
* Updated `modules/scrapper.py` to use `with_retry` when fetching free games from the Epic Games API, retrying up to 4 times on timeout or connection errors, and returning an empty list if all attempts fail.
* Updated `modules/notifier.py` to use `with_retry` for Discord webhook requests, retrying up to 2 times on timeout or connection errors. Also improved error messages to clarify when all retry attempts are exhausted. [[1]](diffhunk://#diff-91904965bc8dcf8b915a29ee992f3dba72335df7bb65f7886cf9e1308ecab1dbR7-R16) [[2]](diffhunk://#diff-91904965bc8dcf8b915a29ee992f3dba72335df7bb65f7886cf9e1308ecab1dbL124-R137) [[3]](diffhunk://#diff-91904965bc8dcf8b915a29ee992f3dba72335df7bb65f7886cf9e1308ecab1dbL143-R155)

**Testing and validation:**

* Added `tests/test_retry.py` with comprehensive unit tests for the `with_retry` utility, as well as integration tests verifying retry behavior in both the Epic Games API fetch and Discord notification flows.

Closes #13 