### PR TITLE
Add REST API for health, metrics, and notification management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,15 @@ ENABLE_HEALTHCHECK=false
 #   24-hour example: "%d/%m/%Y %H:%M"  → 31/01/2025 15:00  (omit %p for 24-hour formats)
 # DATE_FORMAT=%d de %B de %Y a las %I:%M %p
 
+# Optional: API key for protecting mutating REST API endpoints (POST requests)
+# If not set, no authentication is required.
+# API_KEY=your_secret_api_key_here
+
+# Optional: Host and port for the REST API server
+# Defaults to 0.0.0.0:8000. Use 127.0.0.1 for local-only access.
+# API_HOST=0.0.0.0
+# API_PORT=8000
+
 # =============================================================================
 # Setup Instructions:
 # 1. Copy this file: cp .env.example .env
@@ -77,4 +86,5 @@ ENABLE_HEALTHCHECK=false
 # 3. (Optional) Add database credentials if using PostgreSQL
 # 4. (Optional) Add health check URL if monitoring uptime
 # 5. (Optional) Set TIMEZONE, LOCALE, EPIC_GAMES_REGION to match your region
+# 6. (Optional) Set API_KEY to protect mutating API endpoints
 # =============================================================================

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ RUN mkdir -p /mnt/logs /mnt/data /app/data \
 # Switch to non-root user for all subsequent instructions and runtime
 USER appuser
 
+# Expose the REST API port (default 8000, configurable via API_PORT env var)
+EXPOSE 8000
+
 # Health check: confirm the main Python process is running
 HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --retries=3 \
     CMD /app/healthcheck.sh

--- a/api.py
+++ b/api.py
@@ -1,0 +1,384 @@
+"""REST API for the Free Games Notifier service."""
+
+import threading
+import time
+import logging
+from typing import List, Optional
+
+import requests as requests_lib
+from fastapi import FastAPI, HTTPException, Query, Security
+from fastapi.security import APIKeyHeader
+from pydantic import BaseModel, Field
+
+from config import (
+    API_KEY,
+    DB_HOST,
+    DB_NAME,
+    DB_PASSWORD,
+    DB_PORT,
+    DB_USER,
+    DATA_FILE_PATH,
+    DATE_FORMAT,
+    ENABLE_HEALTHCHECK,
+    EPIC_GAMES_API_URL,
+    EPIC_GAMES_REGION,
+    HEALTHCHECK_INTERVAL,
+    HEALTHCHECK_URL,
+    LOCALE,
+    SCHEDULE_TIME,
+    TIMEZONE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic response models (for OpenAPI / Swagger documentation)
+# ---------------------------------------------------------------------------
+
+
+class GameItem(BaseModel):
+    """A free game as returned by the scraper."""
+    title: str = Field(..., description="Name of the free game", examples=["Celeste"])
+    link: str = Field(..., description="Epic Games Store URL for the game")
+    end_date: str = Field(..., description="ISO-8601 timestamp when the free promotion ends", examples=["2024-01-31T15:00:00.000Z"])
+    description: str = Field(..., description="Short description of the game")
+    thumbnail: str = Field(..., description="URL to the game's thumbnail image")
+
+
+class HealthResponse(BaseModel):
+    """Response from the health check endpoint."""
+    status: str = Field(..., description="Overall health status", examples=["healthy", "unhealthy"])
+    epic_games_api: str = Field(..., description="Epic Games API reachability", examples=["healthy", "unhealthy"])
+    database: str = Field(..., description="Database connectivity status", examples=["healthy", "unhealthy", "not_configured"])
+
+
+class GamesLatestResponse(BaseModel):
+    """Response from the latest games endpoint."""
+    games: List[GameItem] = Field(..., description="List of the most recently fetched games")
+    count: int = Field(..., description="Number of games returned", examples=[3])
+
+
+class GamesHistoryResponse(BaseModel):
+    """Response from the paginated game history endpoint."""
+    games: List[GameItem] = Field(..., description="List of games for the current page")
+    total: int = Field(..., description="Total number of games in storage", examples=[42])
+    limit: int = Field(..., description="Maximum number of games per page", examples=[20])
+    offset: int = Field(..., description="Number of games skipped", examples=[0])
+
+
+class ResendResponse(BaseModel):
+    """Response after re-sending a Discord notification."""
+    status: str = Field(..., description="Result of the operation", examples=["success"])
+    games_sent: int = Field(..., description="Number of games included in the notification", examples=[2])
+
+
+class MetricsResponse(BaseModel):
+    """Service metrics snapshot."""
+    uptime_seconds: float = Field(..., description="Seconds since the API server started", examples=[3600.5])
+    games_processed: int = Field(..., description="Total games processed since startup", examples=[12])
+    discord_notifications_sent: int = Field(..., description="Successful Discord notifications sent", examples=[5])
+    discord_notification_errors: int = Field(..., description="Failed Discord notification attempts", examples=[1])
+    errors: int = Field(..., description="Total error count across all operations", examples=[2])
+
+
+class ConfigResponse(BaseModel):
+    """Non-secret runtime configuration."""
+    epic_games_api_url: str = Field(..., description="Epic Games API endpoint URL")
+    epic_games_region: str = Field(..., description="Region code used in store links", examples=["es-MX"])
+    data_file_path: str = Field(..., description="Path to the JSON storage file")
+    enable_healthcheck: bool = Field(..., description="Whether the external health check ping is enabled")
+    healthcheck_configured: bool = Field(..., description="Whether an external health check monitor URL is configured")
+    healthcheck_interval_minutes: int = Field(..., description="Interval in minutes between health check pings", examples=[1])
+    db_host: Optional[str] = Field(None, description="PostgreSQL host (None when DB is not configured)")
+    db_port: int = Field(..., description="PostgreSQL port", examples=[5432])
+    db_name: Optional[str] = Field(None, description="PostgreSQL database name")
+    db_user: Optional[str] = Field(None, description="PostgreSQL user")
+    timezone: str = Field(..., description="Configured timezone for date display", examples=["America/Mexico_City"])
+    locale: str = Field(..., description="Locale used for date formatting", examples=["es_ES.UTF-8"])
+    schedule_time: str = Field(..., description="Daily check time in HH:MM format", examples=["12:00"])
+    date_format: str = Field(..., description="strftime format string for promotion end dates")
+
+
+class CheckE2EResponse(BaseModel):
+    """Response from the end-to-end check endpoint."""
+    games_fetched: int = Field(..., description="Number of free games fetched from Epic Games", examples=[2])
+    games: List[GameItem] = Field(..., description="Full list of fetched game objects")
+    already_in_storage: List[str] = Field(..., description="Titles of games that were already saved in storage")
+    new_games: List[str] = Field(..., description="Titles of games not yet in storage")
+    notification_status: str = Field(..., description="Discord notification result", examples=["sent", "skipped", "failed: ..."])
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response."""
+    detail: str = Field(..., description="Human-readable error message")
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Metrics state (module-level, shared across requests)
+# ---------------------------------------------------------------------------
+
+_start_time = time.time()
+_metrics = {
+    "games_processed": 0,
+    "discord_notifications_sent": 0,
+    "discord_notification_errors": 0,
+    "errors": 0,
+}
+_metrics_lock = threading.Lock()
+
+
+def increment_metric(key: str, amount: int = 1):
+    """Safely increment a metric counter."""
+    with _metrics_lock:
+        if key in _metrics:
+            _metrics[key] += amount
+
+
+# ---------------------------------------------------------------------------
+# FastAPI application
+# ---------------------------------------------------------------------------
+
+app = FastAPI(
+    title="Free Games Notifier API",
+    description="REST API for monitoring and managing the Free Games Notifier service.",
+    version="1.0.0",
+)
+
+# ---------------------------------------------------------------------------
+# API Key authentication
+# ---------------------------------------------------------------------------
+
+_api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+async def _verify_api_key(api_key: str = Security(_api_key_header)):
+    """Validate the API key for mutating endpoints.
+
+    When ``API_KEY`` is not set the check is skipped so that local /
+    development deployments work out-of-the-box without auth.
+    """
+    if not API_KEY:
+        return
+    if api_key != API_KEY:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.get("/health", response_model=HealthResponse)
+def health():
+    """Active health check: Epic Games API reachability and database connectivity."""
+    result = {"epic_games_api": "unknown", "database": "not_configured"}
+
+    # Check Epic Games API
+    try:
+        resp = requests_lib.get(EPIC_GAMES_API_URL, timeout=10)
+        result["epic_games_api"] = "healthy" if resp.status_code == 200 else "unhealthy"
+    except Exception:
+        result["epic_games_api"] = "unhealthy"
+
+    # Check database if configured
+    if DB_HOST:
+        try:
+            import psycopg2
+            conn = psycopg2.connect(
+                host=DB_HOST,
+                port=DB_PORT,
+                dbname=DB_NAME,
+                user=DB_USER,
+                password=DB_PASSWORD,
+                connect_timeout=5,
+            )
+            conn.close()
+            result["database"] = "healthy"
+        except Exception:
+            result["database"] = "unhealthy"
+
+    overall = "healthy"
+    if result["epic_games_api"] != "healthy":
+        overall = "unhealthy"
+    if DB_HOST and result["database"] != "healthy":
+        overall = "unhealthy"
+    result["status"] = overall
+    return result
+
+
+@app.get(
+    "/games/latest",
+    response_model=GamesLatestResponse,
+    responses={500: {"model": ErrorResponse, "description": "Failed to load games from storage"}},
+)
+def games_latest():
+    """Return the most recently fetched games from the configured storage backend."""
+    from modules.storage import load_previous_games
+
+    try:
+        games = load_previous_games()
+        return {"games": games, "count": len(games)}
+    except Exception as e:
+        logger.error("Failed to load latest games: %s", e)
+        increment_metric("errors")
+        raise HTTPException(status_code=500, detail="Failed to load games")
+
+
+@app.get(
+    "/games/history",
+    response_model=GamesHistoryResponse,
+    responses={500: {"model": ErrorResponse, "description": "Failed to load game history"}},
+)
+def games_history(
+    limit: int = Query(default=20, ge=1, le=100, description="Max number of games to return"),
+    offset: int = Query(default=0, ge=0, description="Number of games to skip"),
+):
+    """Paginated access to all past fetched games.
+
+    Query parameters:
+    - **limit**: Max number of games to return (1–100, default: 20)
+    - **offset**: Number of games to skip (default: 0)
+    """
+    from modules.storage import load_previous_games
+
+    try:
+        all_games = load_previous_games()
+        total = len(all_games)
+        page = all_games[offset : offset + limit]
+        return {"games": page, "total": total, "limit": limit, "offset": offset}
+    except Exception as e:
+        logger.error("Failed to load game history: %s", e)
+        increment_metric("errors")
+        raise HTTPException(status_code=500, detail="Failed to load game history")
+
+
+@app.post(
+    "/notify/discord/resend",
+    response_model=ResendResponse,
+    dependencies=[Security(_verify_api_key)],
+    responses={
+        401: {"model": ErrorResponse, "description": "Invalid or missing API key"},
+        404: {"model": ErrorResponse, "description": "No games available to resend"},
+        500: {"model": ErrorResponse, "description": "Failed to send Discord notification"},
+    },
+)
+def notify_discord_resend():
+    """Re-send the latest fetched games to the Discord webhook."""
+    from modules.storage import load_previous_games
+    from modules.notifier import send_discord_message
+
+    try:
+        games = load_previous_games()
+    except Exception as e:
+        logger.error("Failed to load games for resend: %s", e)
+        increment_metric("errors")
+        raise HTTPException(status_code=500, detail="Failed to load games")
+
+    if not games:
+        raise HTTPException(status_code=404, detail="No games available to resend")
+
+    try:
+        send_discord_message(games)
+        increment_metric("discord_notifications_sent")
+        return {"status": "success", "games_sent": len(games)}
+    except Exception as e:
+        logger.error("Failed to resend Discord notification: %s", e, exc_info=True)
+        increment_metric("discord_notification_errors")
+        increment_metric("errors")
+        raise HTTPException(status_code=500, detail="Failed to send Discord notification")
+
+
+@app.get("/metrics", response_model=MetricsResponse)
+def metrics():
+    """Basic service metrics: uptime, games processed, notifications sent, errors."""
+    uptime_seconds = time.time() - _start_time
+    with _metrics_lock:
+        snapshot = dict(_metrics)
+    return {
+        "uptime_seconds": round(uptime_seconds, 2),
+        **snapshot,
+    }
+
+
+@app.get("/config", response_model=ConfigResponse)
+def config_endpoint():
+    """Expose non-secret runtime configuration."""
+    return {
+        "epic_games_api_url": EPIC_GAMES_API_URL,
+        "epic_games_region": EPIC_GAMES_REGION,
+        "data_file_path": DATA_FILE_PATH,
+        "enable_healthcheck": ENABLE_HEALTHCHECK,
+        "healthcheck_configured": bool(HEALTHCHECK_URL),
+        "healthcheck_interval_minutes": HEALTHCHECK_INTERVAL,
+        "db_host": DB_HOST,
+        "db_port": DB_PORT,
+        "db_name": DB_NAME,
+        "db_user": DB_USER,
+        "timezone": TIMEZONE,
+        "locale": LOCALE,
+        "schedule_time": SCHEDULE_TIME,
+        "date_format": DATE_FORMAT,
+    }
+
+
+@app.post(
+    "/check",
+    response_model=CheckE2EResponse,
+    dependencies=[Security(_verify_api_key)],
+    responses={
+        401: {"model": ErrorResponse, "description": "Invalid or missing API key"},
+        404: {"model": ErrorResponse, "description": "No free games found from Epic Games API"},
+        500: {"model": ErrorResponse, "description": "Failed to fetch games from Epic Games API"},
+    },
+)
+def check_e2e():
+    """End-to-end test: fetch games, check DB presence, and send Discord notification regardless.
+
+    This endpoint runs the full flow even when the games already exist in the
+    database so you can test the pipeline without deleting stored data.
+    """
+    from modules.scrapper import fetch_free_games
+    from modules.storage import load_previous_games
+    from modules.notifier import send_discord_message
+
+    # 1. Fetch current free games from Epic Games
+    try:
+        current_games = fetch_free_games()
+        increment_metric("games_processed", len(current_games))
+    except Exception as e:
+        logger.error("E2E check – failed to fetch games: %s", e)
+        increment_metric("errors")
+        raise HTTPException(status_code=500, detail="Failed to fetch games")
+
+    if not current_games:
+        raise HTTPException(status_code=404, detail="No free games found from Epic Games API")
+
+    # 2. Check which games already exist in storage
+    try:
+        previous_games = load_previous_games()
+    except Exception as e:
+        logger.error("E2E check – failed to load previous games: %s", e)
+        previous_games = []
+
+    already_saved = [g for g in current_games if g in previous_games]
+    new_games = [g for g in current_games if g not in previous_games]
+
+    # 3. Send Discord notification regardless of DB state
+    notification_status = "skipped"
+    try:
+        send_discord_message(current_games)
+        notification_status = "sent"
+        increment_metric("discord_notifications_sent")
+    except Exception as e:
+        logger.error("E2E check – Discord notification failed: %s", e)
+        notification_status = f"failed: {e}"
+        increment_metric("discord_notification_errors")
+        increment_metric("errors")
+
+    return {
+        "games_fetched": len(current_games),
+        "games": current_games,
+        "already_in_storage": [g.get("title", "") for g in already_saved],
+        "new_games": [g.get("title", "") for g in new_games],
+        "notification_status": notification_status,
+    }

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,7 +18,12 @@ services:
       - EPIC_GAMES_REGION=${EPIC_GAMES_REGION:-es-MX}
       - SCHEDULE_TIME=${SCHEDULE_TIME:-12:00}
       - HEALTHCHECK_INTERVAL=${HEALTHCHECK_INTERVAL:-1}
+      - API_KEY=${API_KEY}
+      - API_HOST=${API_HOST:-0.0.0.0}
+      - API_PORT=${API_PORT:-8000}
     image: free-games-notifier
+    ports:
+      - "${API_PORT:-8000}:${API_PORT:-8000}"
     restart: unless-stopped
     volumes:
       - type: bind

--- a/config.py
+++ b/config.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from dotenv import load_dotenv
 
@@ -55,3 +56,27 @@ except ValueError:
 # strftime format string used when displaying the promotion end date in Discord notifications.
 # The default is Spanish-style; change to match your locale, e.g. "%B %d, %Y at %I:%M" for en-US.
 DATE_FORMAT = os.getenv("DATE_FORMAT", "%d de %B de %Y a las %I:%M %p")
+
+# REST API configuration
+API_KEY = os.getenv("API_KEY")  # Secret key for mutating API endpoints; leave empty to disable auth
+API_HOST = os.getenv("API_HOST", "0.0.0.0")
+_raw_api_port = os.getenv("API_PORT")
+try:
+    if _raw_api_port in (None, ""):
+        API_PORT = 8000
+    else:
+        _parsed_api_port = int(_raw_api_port)
+        if 1 <= _parsed_api_port <= 65535:
+            API_PORT = _parsed_api_port
+        else:
+            logging.error(
+                "API_PORT '%s' is out of valid range (1–65535); defaulting to 8000",
+                _raw_api_port,
+            )
+            API_PORT = 8000
+except ValueError:
+    logging.error(
+        "Invalid API_PORT '%s' (not a number); defaulting to 8000",
+        _raw_api_port,
+    )
+    API_PORT = 8000

--- a/main.py
+++ b/main.py
@@ -5,11 +5,12 @@ from modules.scrapper import fetch_free_games
 from modules.storage import load_previous_games, save_games
 from modules.healthcheck import healthcheck
 from modules.database import FreeGamesDatabase
-from config import DB_HOST, SCHEDULE_TIME, HEALTHCHECK_INTERVAL, TIMEZONE
+from config import DB_HOST, SCHEDULE_TIME, HEALTHCHECK_INTERVAL, TIMEZONE, API_HOST, API_PORT
 
 import os
 import schedule
 import time
+import threading
 import requests
 
 from alembic.config import Config as AlembicConfig
@@ -121,6 +122,15 @@ def _run_db_migrations():
     logging.info("Database migrations applied successfully.")
 
 
+def _start_api_server():
+    """Start the FastAPI server in a background daemon thread."""
+    import uvicorn
+    from api import app
+
+    logging.info("Starting REST API server on %s:%s...", API_HOST, API_PORT)
+    uvicorn.run(app, host=API_HOST, port=API_PORT, log_level="info")
+
+
 def main():
     if DB_HOST:
         logging.info("Database configuration detected. Initializing database...")
@@ -129,6 +139,11 @@ def main():
         _run_db_migrations()
     else:
         logging.info("No database configuration detected. Using JSON file storage.")
+
+    # Start REST API server in a background thread
+    api_thread = threading.Thread(target=_start_api_server, daemon=True)
+    api_thread.start()
+
     check_games()
     healthcheck()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest>=7.4
 pytest-mock>=3.10
+httpx>=0.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ alembic==1.16.5
 beautifulsoup4==4.13.3
 certifi==2025.1.31
 charset-normalizer==3.4.1
+fastapi==0.115.12
 idna==3.10
 psycopg2-binary==2.9.11
 python-dotenv==1.0.1
@@ -13,3 +14,4 @@ SQLAlchemy==2.0.48
 typeguard==4.4.2
 typing_extensions==4.12.2
 urllib3==2.3.0
+uvicorn==0.34.2

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,339 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from fastapi.testclient import TestClient
+
+from api import app, _metrics, _start_time, increment_metric
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics():
+    """Reset metrics counters before each test."""
+    original = dict(_metrics)
+    for key in _metrics:
+        _metrics[key] = 0
+    yield
+    _metrics.update(original)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# GET /health
+# ---------------------------------------------------------------------------
+
+class TestHealthEndpoint:
+    def test_returns_healthy_when_api_reachable(self, client):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        with patch("api.requests_lib.get", return_value=mock_resp), \
+             patch("api.DB_HOST", None):
+            resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["epic_games_api"] == "healthy"
+        assert data["database"] == "not_configured"
+        assert data["status"] == "healthy"
+
+    def test_returns_unhealthy_when_api_unreachable(self, client):
+        with patch("api.requests_lib.get", side_effect=Exception("timeout")), \
+             patch("api.DB_HOST", None):
+            resp = client.get("/health")
+        data = resp.json()
+        assert data["epic_games_api"] == "unhealthy"
+        assert data["status"] == "unhealthy"
+
+    def test_returns_unhealthy_on_non_200_status(self, client):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        with patch("api.requests_lib.get", return_value=mock_resp), \
+             patch("api.DB_HOST", None):
+            resp = client.get("/health")
+        data = resp.json()
+        assert data["epic_games_api"] == "unhealthy"
+
+    def test_checks_database_when_configured(self, client):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_conn = MagicMock()
+        with patch("api.requests_lib.get", return_value=mock_resp), \
+             patch("api.DB_HOST", "localhost"), \
+             patch("api.DB_PORT", 5432), \
+             patch("api.DB_NAME", "test"), \
+             patch("api.DB_USER", "user"), \
+             patch("psycopg2.connect", return_value=mock_conn):
+            resp = client.get("/health")
+        data = resp.json()
+        assert data["database"] == "healthy"
+        mock_conn.close.assert_called_once()
+
+    def test_database_unhealthy_on_connection_error(self, client):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        with patch("api.requests_lib.get", return_value=mock_resp), \
+             patch("api.DB_HOST", "localhost"), \
+             patch("api.DB_PORT", 5432), \
+             patch("api.DB_NAME", "test"), \
+             patch("api.DB_USER", "user"), \
+             patch("psycopg2.connect", side_effect=Exception("connection refused")):
+            resp = client.get("/health")
+        data = resp.json()
+        assert data["database"] == "unhealthy"
+        assert data["status"] == "unhealthy"
+
+
+# ---------------------------------------------------------------------------
+# GET /games/latest
+# ---------------------------------------------------------------------------
+
+class TestGamesLatestEndpoint:
+    def test_returns_games(self, client, sample_games):
+        with patch("modules.storage.load_previous_games", return_value=sample_games):
+            resp = client.get("/games/latest")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["games"][0]["title"] == "Test Free Game"
+
+    def test_returns_empty_list_when_no_games(self, client):
+        with patch("modules.storage.load_previous_games", return_value=[]):
+            resp = client.get("/games/latest")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 0
+        assert data["games"] == []
+
+    def test_returns_500_on_error(self, client):
+        with patch("modules.storage.load_previous_games", side_effect=Exception("disk error")):
+            resp = client.get("/games/latest")
+        assert resp.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# GET /games/history
+# ---------------------------------------------------------------------------
+
+class TestGamesHistoryEndpoint:
+    def test_returns_paginated_results(self, client, sample_game):
+        games = [dict(sample_game, title=f"Game {i}") for i in range(5)]
+        with patch("modules.storage.load_previous_games", return_value=games):
+            resp = client.get("/games/history?limit=2&offset=1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 5
+        assert data["limit"] == 2
+        assert data["offset"] == 1
+        assert len(data["games"]) == 2
+        assert data["games"][0]["title"] == "Game 1"
+
+    def test_default_pagination(self, client, sample_games):
+        with patch("modules.storage.load_previous_games", return_value=sample_games):
+            resp = client.get("/games/history")
+        data = resp.json()
+        assert data["limit"] == 20
+        assert data["offset"] == 0
+
+    def test_rejects_invalid_limit(self, client):
+        resp = client.get("/games/history?limit=0")
+        assert resp.status_code == 422
+
+    def test_rejects_negative_offset(self, client):
+        resp = client.get("/games/history?offset=-1")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /notify/discord/resend
+# ---------------------------------------------------------------------------
+
+class TestNotifyDiscordResendEndpoint:
+    def test_resends_notification_successfully(self, client, sample_games):
+        with patch("modules.storage.load_previous_games", return_value=sample_games), \
+             patch("modules.notifier.send_discord_message") as mock_send:
+            resp = client.post("/notify/discord/resend")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "success"
+        assert data["games_sent"] == 1
+        mock_send.assert_called_once_with(sample_games)
+
+    def test_returns_404_when_no_games(self, client):
+        with patch("modules.storage.load_previous_games", return_value=[]):
+            resp = client.post("/notify/discord/resend")
+        assert resp.status_code == 404
+
+    def test_returns_500_on_discord_error(self, client, sample_games):
+        with patch("modules.storage.load_previous_games", return_value=sample_games), \
+             patch("modules.notifier.send_discord_message", side_effect=Exception("webhook error")):
+            resp = client.post("/notify/discord/resend")
+        assert resp.status_code == 500
+
+    def test_rejects_invalid_api_key(self, client, sample_games):
+        with patch("api.API_KEY", "valid-key"):
+            resp = client.post("/notify/discord/resend", headers={"X-API-Key": "wrong-key"})
+        assert resp.status_code == 401
+
+    def test_accepts_valid_api_key(self, client, sample_games):
+        with patch("api.API_KEY", "valid-key"), \
+             patch("modules.storage.load_previous_games", return_value=sample_games), \
+             patch("modules.notifier.send_discord_message"):
+            resp = client.post("/notify/discord/resend", headers={"X-API-Key": "valid-key"})
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /metrics
+# ---------------------------------------------------------------------------
+
+class TestMetricsEndpoint:
+    def test_returns_metrics(self, client):
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "uptime_seconds" in data
+        assert "games_processed" in data
+        assert "discord_notifications_sent" in data
+        assert "errors" in data
+
+    def test_uptime_is_positive(self, client):
+        resp = client.get("/metrics")
+        data = resp.json()
+        assert data["uptime_seconds"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# GET /config
+# ---------------------------------------------------------------------------
+
+class TestConfigEndpoint:
+    def test_returns_config(self, client):
+        resp = client.get("/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "epic_games_api_url" in data
+        assert "timezone" in data
+        assert "schedule_time" in data
+
+    def test_does_not_expose_secrets(self, client):
+        resp = client.get("/config")
+        data = resp.json()
+        data_str = str(data)
+        assert "DB_PASSWORD" not in data_str
+        assert "DISCORD_WEBHOOK_URL" not in data_str
+        assert "API_KEY" not in data_str
+        # Ensure the actual secret values are not keys
+        assert "password" not in data
+        assert "webhook" not in data
+        assert "api_key" not in data
+
+
+# ---------------------------------------------------------------------------
+# POST /check (E2E test endpoint)
+# ---------------------------------------------------------------------------
+
+class TestCheckE2EEndpoint:
+    def test_full_flow_new_games(self, client, sample_games):
+        with patch("modules.scrapper.fetch_free_games", return_value=sample_games), \
+             patch("modules.storage.load_previous_games", return_value=[]), \
+             patch("modules.notifier.send_discord_message"):
+            resp = client.post("/check")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["games_fetched"] == 1
+        assert data["notification_status"] == "sent"
+        assert len(data["new_games"]) == 1
+        assert len(data["already_in_storage"]) == 0
+
+    def test_full_flow_games_already_saved(self, client, sample_games):
+        with patch("modules.scrapper.fetch_free_games", return_value=sample_games), \
+             patch("modules.storage.load_previous_games", return_value=sample_games), \
+             patch("modules.notifier.send_discord_message"):
+            resp = client.post("/check")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["already_in_storage"]) == 1
+        assert len(data["new_games"]) == 0
+        assert data["notification_status"] == "sent"
+
+    def test_returns_404_when_no_free_games(self, client):
+        with patch("modules.scrapper.fetch_free_games", return_value=[]):
+            resp = client.post("/check")
+        assert resp.status_code == 404
+
+    def test_handles_discord_failure(self, client, sample_games):
+        with patch("modules.scrapper.fetch_free_games", return_value=sample_games), \
+             patch("modules.storage.load_previous_games", return_value=[]), \
+             patch("modules.notifier.send_discord_message", side_effect=Exception("webhook error")):
+            resp = client.post("/check")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "failed" in data["notification_status"]
+
+    def test_returns_500_on_scraper_error(self, client):
+        with patch("modules.scrapper.fetch_free_games", side_effect=Exception("API error")):
+            resp = client.post("/check")
+        assert resp.status_code == 500
+
+    def test_rejects_invalid_api_key(self, client):
+        with patch("api.API_KEY", "valid-key"):
+            resp = client.post("/check", headers={"X-API-Key": "wrong-key"})
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# API Key authentication
+# ---------------------------------------------------------------------------
+
+class TestAPIKeyAuth:
+    def test_no_auth_required_when_api_key_not_set(self, client, sample_games):
+        with patch("api.API_KEY", None), \
+             patch("modules.storage.load_previous_games", return_value=sample_games), \
+             patch("modules.notifier.send_discord_message"):
+            resp = client.post("/notify/discord/resend")
+        assert resp.status_code == 200
+
+    def test_auth_required_when_api_key_set(self, client):
+        with patch("api.API_KEY", "secret-key"):
+            resp = client.post("/notify/discord/resend")
+        assert resp.status_code == 401
+
+    def test_valid_key_allows_access(self, client, sample_games):
+        with patch("api.API_KEY", "secret-key"), \
+             patch("modules.storage.load_previous_games", return_value=sample_games), \
+             patch("modules.notifier.send_discord_message"):
+            resp = client.post(
+                "/notify/discord/resend",
+                headers={"X-API-Key": "secret-key"},
+            )
+        assert resp.status_code == 200
+
+    def test_read_endpoints_do_not_require_auth(self, client):
+        with patch("api.API_KEY", "secret-key"):
+            # GET endpoints should work without API key
+            with patch("modules.storage.load_previous_games", return_value=[]):
+                assert client.get("/games/latest").status_code == 200
+            assert client.get("/metrics").status_code == 200
+            assert client.get("/config").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# increment_metric helper
+# ---------------------------------------------------------------------------
+
+class TestIncrementMetric:
+    def test_increments_existing_key(self):
+        _metrics["errors"] = 0
+        increment_metric("errors")
+        assert _metrics["errors"] == 1
+
+    def test_ignores_unknown_key(self):
+        increment_metric("nonexistent_key")
+        # Should not raise
+
+    def test_increments_by_custom_amount(self):
+        _metrics["games_processed"] = 0
+        increment_metric("games_processed", 5)
+        assert _metrics["games_processed"] == 5

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -69,6 +69,7 @@ class TestMainDbBranch:
         with patch("main.DB_HOST", "localhost"), \
              patch("main.FreeGamesDatabase", return_value=mock_db), \
              patch("main._run_db_migrations") as mock_migrate, \
+             patch("main._start_api_server"), \
              patch("main.check_games"), \
              patch("main.healthcheck"), \
              patch("main.schedule"), \
@@ -88,6 +89,7 @@ class TestMainDbBranch:
         with patch("main.DB_HOST", None), \
              patch("main._run_db_migrations") as mock_migrate, \
              patch("main.FreeGamesDatabase") as mock_db_cls, \
+             patch("main._start_api_server"), \
              patch("main.check_games"), \
              patch("main.healthcheck"), \
              patch("main.schedule"), \


### PR DESCRIPTION
This pull request introduces a REST API to the Free Games Notifier service, enabling external monitoring, management, and integration with other systems. The API is built using FastAPI and includes endpoints for health checks, retrieving game data, sending Discord notifications, service metrics, and configuration. The change also adds API key authentication for mutating endpoints, environment variable configuration, Docker and Compose support for the API, and starts the API server in a background thread alongside the main process.

Key changes:

**REST API Implementation:**
- Added a new `api.py` module implementing a FastAPI-based REST API with endpoints for health checks, latest games, paginated game history, Discord notification resend, service metrics, configuration, and an end-to-end test. Includes OpenAPI documentation, API key authentication, and metrics tracking.

**Configuration and Environment:**
- Extended `.env.example` to document new API-related environment variables (`API_KEY`, `API_HOST`, `API_PORT`) for authentication and server configuration.
- Updated `config.py` to load and validate API configuration variables, including robust parsing and error handling for the API port. [[1]](diffhunk://#diff-117426151e93a626f8b46bfdb3a95b3f4a62e5f4dd6e65975a7c50759bf04482R59-R82) [[2]](diffhunk://#diff-117426151e93a626f8b46bfdb3a95b3f4a62e5f4dd6e65975a7c50759bf04482R1)

**Deployment and Dockerization:**
- Modified `Dockerfile` to expose the API port (default 8000) for external access.
- Updated `compose.yaml` to pass API environment variables and map the API port, enabling containerized deployments to expose the REST API.

**Service Startup:**
- Updated `main.py` to start the FastAPI server in a background daemon thread, allowing the REST API to run concurrently with the existing scheduled tasks and health checks. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L8-R13) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R125-R133) [[3]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R142-R146)

**Development Dependencies:**
- Added `httpx` to `requirements-dev.txt` to support API endpoint testing.

Closes #29 