### PR TITLE
Standardize environment defaults and add LOCALE build argument in compose file

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,6 +2,8 @@ services:
   free-games-notifier:
     build:
       context: .
+      args:
+        LOCALE: ${LOCALE:-en_US.UTF-8}
     container_name: free-games-notifier
     environment:
       - DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL} 
@@ -13,10 +15,10 @@ services:
       - DB_NAME=${DB_NAME}
       - DB_USER=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}
-      - TIMEZONE=${TIMEZONE:-America/Mexico_City}
-      - LOCALE=${LOCALE-es_ES.UTF-8}
-      - "DATE_FORMAT=${DATE_FORMAT:-%d de %B de %Y a las %I:%M %p}"
-      - "EPIC_GAMES_REGION=${EPIC_GAMES_REGION:-es-MX}"
+      - TIMEZONE=${TIMEZONE:-UTC}
+      - LOCALE=${LOCALE-en_US.UTF-8}
+      - "DATE_FORMAT=${DATE_FORMAT:-%B %d, %Y at %I:%M %p}"
+      - "EPIC_GAMES_REGION=${EPIC_GAMES_REGION:-en-US}"
       - SCHEDULE_TIME=${SCHEDULE_TIME:-12:00}
       - HEALTHCHECK_INTERVAL=${HEALTHCHECK_INTERVAL:-1}
       - API_KEY=${API_KEY}


### PR DESCRIPTION
This pull request updates the Docker Compose configuration to standardize the application's locale, timezone, and formatting defaults to US English. The changes ensure consistency in environment variables and build arguments for the `free-games-notifier` service.

Configuration and localization updates:

* Added a build argument for `LOCALE` with a default value of `en_US.UTF-8` to the `free-games-notifier` service build configuration.
* Updated environment variable defaults for `TIMEZONE`, `LOCALE`, `DATE_FORMAT`, and `EPIC_GAMES_REGION` to use US English values (`UTC`, `en_US.UTF-8`, `%B %d, %Y at %I:%M %p`, and `en-US` respectively), replacing previous Spanish/Mexico-centric defaults.