### PR TITLE
Add optional webhook_url override for notify and check endpoints

### DIFF
--- a/api.py
+++ b/api.py
@@ -8,8 +8,9 @@ from typing import List, Optional
 import requests as requests_lib
 from fastapi import FastAPI, HTTPException, Query, Security
 from fastapi.security import APIKeyHeader
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from modules.notifier import validate_discord_webhook_url
 from config import (
     API_KEY,
     DB_HOST,
@@ -111,6 +112,37 @@ class ErrorResponse(BaseModel):
     """Standard error response."""
     detail: str = Field(..., description="Human-readable error message")
 
+
+class WebhookOverrideRequest(BaseModel):
+    """Optional request body for Discord notification endpoints.
+
+    Allows callers to specify an alternative Discord webhook URL so that
+    test/E2E runs can target a non-default channel without changing global
+    configuration.  The ``webhook_url`` field is validated to allow only
+    legitimate Discord webhook URLs, preventing SSRF attacks.
+    """
+
+    webhook_url: Optional[str] = Field(
+        None,
+        description=(
+            "Override Discord webhook URL for this request. "
+            "Must be a valid Discord webhook URL "
+            "(https://discord.com/api/webhooks/... or https://discordapp.com/api/webhooks/...)."
+        ),
+    )
+
+    @field_validator("webhook_url")
+    @classmethod
+    def _validate_webhook_url(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+
+        v_stripped = v.strip()
+        if not v_stripped:
+            raise ValueError("webhook_url must not be empty or whitespace")
+
+        validate_discord_webhook_url(v_stripped)
+        return v_stripped
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -262,10 +294,12 @@ def games_history(
         500: {"model": ErrorResponse, "description": "Failed to send Discord notification"},
     },
 )
-def notify_discord_resend():
+def notify_discord_resend(body: Optional[WebhookOverrideRequest] = None):
     """Re-send the latest fetched games to the Discord webhook."""
     from modules.storage import load_previous_games
     from modules.notifier import send_discord_message
+
+    webhook_url = body.webhook_url if body else None
 
     try:
         games = load_previous_games()
@@ -278,7 +312,7 @@ def notify_discord_resend():
         raise HTTPException(status_code=404, detail="No games available to resend")
 
     try:
-        send_discord_message(games)
+        send_discord_message(games, webhook_url=webhook_url)
         increment_metric("discord_notifications_sent")
         return {"status": "success", "games_sent": len(games)}
     except Exception as e:
@@ -331,7 +365,7 @@ def config_endpoint():
         500: {"model": ErrorResponse, "description": "Failed to fetch games from Epic Games API"},
     },
 )
-def check_e2e():
+def check_e2e(body: Optional[WebhookOverrideRequest] = None):
     """End-to-end test: fetch games, check DB presence, and send Discord notification regardless.
 
     This endpoint runs the full flow even when the games already exist in the
@@ -340,6 +374,8 @@ def check_e2e():
     from modules.scrapper import fetch_free_games
     from modules.storage import load_previous_games
     from modules.notifier import send_discord_message
+
+    webhook_url = body.webhook_url if body else None
 
     # 1. Fetch current free games from Epic Games
     try:
@@ -366,7 +402,7 @@ def check_e2e():
     # 3. Send Discord notification regardless of DB state
     notification_status = "skipped"
     try:
-        send_discord_message(current_games)
+        send_discord_message(current_games, webhook_url=webhook_url)
         notification_status = "sent"
         increment_metric("discord_notifications_sent")
     except Exception as e:

--- a/modules/notifier.py
+++ b/modules/notifier.py
@@ -1,6 +1,7 @@
 from config import DISCORD_WEBHOOK_URL, TIMEZONE, LOCALE, DATE_FORMAT, EPIC_GAMES_REGION
 import requests
 from datetime import datetime
+from typing import Optional
 import pytz
 import locale
 from urllib.parse import urlparse
@@ -26,6 +27,35 @@ if LOCALE:
             exc_info=True,
         )
 
+_ALLOWED_DISCORD_HOSTS = frozenset({"discord.com", "discordapp.com"})
+
+
+def validate_discord_webhook_url(url: str) -> None:
+    """
+    Validate that a URL is a legitimate Discord webhook URL.
+
+    Checks that the URL uses HTTPS, targets an allowed Discord host, and has
+    the expected /api/webhooks/ path prefix.  Raises ``ValueError`` with a
+    descriptive message when any check fails.  This is the primary guard
+    against SSRF attacks via user-supplied webhook URLs.
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        raise ValueError("Invalid webhook URL format")
+
+    if parsed.scheme != "https":
+        raise ValueError("Webhook URL must use HTTPS")
+
+    if parsed.hostname not in _ALLOWED_DISCORD_HOSTS:
+        raise ValueError(
+            f"Webhook URL host must be discord.com or discordapp.com, got: {parsed.hostname!r}"
+        )
+
+    if not parsed.path.startswith("/api/webhooks/"):
+        raise ValueError("Webhook URL path must start with /api/webhooks/")
+
+
 def _get_safe_webhook_identifier(webhook_url: str) -> str:
     """
     Return a redacted identifier for a webhook URL that is safe to log.
@@ -36,7 +66,9 @@ def _get_safe_webhook_identifier(webhook_url: str) -> str:
         return "unknown-webhook"
     try:
         parsed = urlparse(webhook_url)
-        host = parsed.netloc or "unknown-host"
+        # Use parsed.hostname (not .netloc) to avoid logging userinfo credentials
+        # if a crafted URL like user:pass@discord.com is somehow supplied.
+        host = parsed.hostname or "unknown-host"
         path = parsed.path or ""
 
         # Expected Discord webhook pattern: /api/webhooks/<id>/<token>
@@ -51,21 +83,39 @@ def _get_safe_webhook_identifier(webhook_url: str) -> str:
         # In case of any parsing error, avoid logging the raw URL
         return "invalid-webhook-url"
 
-def send_discord_message(new_games):
+def send_discord_message(new_games, webhook_url: Optional[str] = None):
     """
     Send a Discord webhook message for new free games.
     
     Args:
         new_games: List of game dictionaries to send to Discord
+        webhook_url: Optional webhook URL override. Defaults to DISCORD_WEBHOOK_URL.
+            Must be a valid Discord webhook URL on either discord.com or discordapp.com
+            (e.g. https://discord.com/api/webhooks/... or https://discordapp.com/api/webhooks/...).
         
     Raises:
-        ValueError: If webhook URL is not configured
+        ValueError: If webhook URL is not configured or fails validation
         requests.RequestException: If the HTTP request fails
     """
-    if not DISCORD_WEBHOOK_URL:
+    # Determine effective webhook URL, giving precedence to an explicit override
+    if webhook_url is not None:
+        override = webhook_url.strip()
+        if not override:
+            error_msg = "Explicit Discord webhook URL override is empty or whitespace-only"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+        effective_webhook_url = override
+    else:
+        effective_webhook_url = DISCORD_WEBHOOK_URL
+
+    if not effective_webhook_url:
         error_msg = "Discord webhook URL not configured in environment variables"
         logger.error(error_msg)
         raise ValueError(error_msg)
+
+    # Validate user-supplied webhook URLs to prevent SSRF
+    if webhook_url is not None:
+        validate_discord_webhook_url(effective_webhook_url)
     
     try:
         embeds = []
@@ -125,11 +175,11 @@ def send_discord_message(new_games):
         }
         logger.info(f"Sending Discord message with {len(embeds)} game(s)")
 
-        safe_webhook_id = _get_safe_webhook_identifier(DISCORD_WEBHOOK_URL)
+        safe_webhook_id = _get_safe_webhook_identifier(effective_webhook_url)
 
         # Send the request with retry logic for transient network errors
         response = with_retry(
-            func=lambda: requests.post(DISCORD_WEBHOOK_URL, json=data, timeout=10),
+            func=lambda: requests.post(effective_webhook_url, json=data, timeout=10),
             max_attempts=2,
             base_delay=1,
             retryable_exceptions=_DISCORD_RETRYABLE,
@@ -150,19 +200,19 @@ def send_discord_message(new_games):
             response.raise_for_status()  # Raise exception for bad status codes
             
     except requests.exceptions.Timeout as e:
-        safe_webhook_id = _get_safe_webhook_identifier(DISCORD_WEBHOOK_URL)
+        safe_webhook_id = _get_safe_webhook_identifier(effective_webhook_url)
         logger.error(
             f"Discord request timed out (10s per-attempt limit, all attempts exhausted) | Webhook identifier: {safe_webhook_id} | Games: {len(new_games)}"
         )
         raise
     except requests.exceptions.ConnectionError as e:
-        safe_webhook_id = _get_safe_webhook_identifier(DISCORD_WEBHOOK_URL)
+        safe_webhook_id = _get_safe_webhook_identifier(effective_webhook_url)
         logger.error(
             f"Discord connection error: {str(e)} | Webhook identifier: {safe_webhook_id} | Games: {len(new_games)}"
         )
         raise
     except requests.exceptions.RequestException as e:
-        safe_webhook_id = _get_safe_webhook_identifier(DISCORD_WEBHOOK_URL)
+        safe_webhook_id = _get_safe_webhook_identifier(effective_webhook_url)
         logger.error(
             f"Discord request failed: {str(e)} | Webhook identifier: {safe_webhook_id} | Games: {len(new_games)}"
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -158,7 +158,7 @@ class TestNotifyDiscordResendEndpoint:
         data = resp.json()
         assert data["status"] == "success"
         assert data["games_sent"] == 1
-        mock_send.assert_called_once_with(sample_games)
+        mock_send.assert_called_once_with(sample_games, webhook_url=None)
 
     def test_returns_404_when_no_games(self, client):
         with patch("modules.storage.load_previous_games", return_value=[]):
@@ -182,6 +182,19 @@ class TestNotifyDiscordResendEndpoint:
              patch("modules.notifier.send_discord_message"):
             resp = client.post("/notify/discord/resend", headers={"X-API-Key": "valid-key"})
         assert resp.status_code == 200
+
+    def test_uses_custom_webhook_url_when_provided(self, client, sample_games):
+        custom_url = "https://discord.com/api/webhooks/9999/custom-token"
+        with patch("modules.storage.load_previous_games", return_value=sample_games), \
+             patch("modules.notifier.send_discord_message") as mock_send:
+            resp = client.post("/notify/discord/resend", json={"webhook_url": custom_url})
+        assert resp.status_code == 200
+        mock_send.assert_called_once_with(sample_games, webhook_url=custom_url)
+
+    def test_rejects_invalid_webhook_url(self, client, sample_games):
+        with patch("modules.storage.load_previous_games", return_value=sample_games):
+            resp = client.post("/notify/discord/resend", json={"webhook_url": "https://evil.com/hook"})
+        assert resp.status_code == 422
 
 
 # ---------------------------------------------------------------------------
@@ -281,6 +294,20 @@ class TestCheckE2EEndpoint:
         with patch("api.API_KEY", "valid-key"):
             resp = client.post("/check", headers={"X-API-Key": "wrong-key"})
         assert resp.status_code == 401
+
+    def test_uses_custom_webhook_url_when_provided(self, client, sample_games):
+        custom_url = "https://discord.com/api/webhooks/9999/custom-token"
+        with patch("modules.scrapper.fetch_free_games", return_value=sample_games), \
+             patch("modules.storage.load_previous_games", return_value=[]), \
+             patch("modules.notifier.send_discord_message") as mock_send:
+            resp = client.post("/check", json={"webhook_url": custom_url})
+        assert resp.status_code == 200
+        mock_send.assert_called_once_with(sample_games, webhook_url=custom_url)
+
+    def test_rejects_invalid_webhook_url(self, client, sample_games):
+        with patch("modules.scrapper.fetch_free_games", return_value=sample_games):
+            resp = client.post("/check", json={"webhook_url": "https://evil.com/hook"})
+        assert resp.status_code == 422
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -209,3 +209,74 @@ class TestSendDiscordMessage:
         with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK):
             with pytest.raises(KeyError):
                 notifier.send_discord_message([bad_game])
+
+
+class TestSendDiscordMessageWebhookOverride:
+    """Tests for the optional webhook_url override in send_discord_message."""
+
+    def _make_response(self, status_code=204):
+        mock_resp = MagicMock()
+        mock_resp.status_code = status_code
+        mock_resp.text = ""
+        mock_resp.raise_for_status = MagicMock()
+        return mock_resp
+
+    def test_override_url_is_used_instead_of_env_var(self, sample_games):
+        """When webhook_url is provided, requests.post() uses it, not DISCORD_WEBHOOK_URL."""
+        override_url = "https://discord.com/api/webhooks/9999/override-token"
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message(sample_games, webhook_url=override_url)
+
+        args, _ = mock_post.call_args
+        assert args[0] == override_url
+        assert args[0] != VALID_WEBHOOK
+
+    def test_env_var_used_when_no_override(self, sample_games):
+        """When webhook_url is not provided, requests.post() uses DISCORD_WEBHOOK_URL."""
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message(sample_games)
+
+        args, _ = mock_post.call_args
+        assert args[0] == VALID_WEBHOOK
+
+    def test_raises_on_non_discord_override_url(self, sample_games):
+        """User-supplied webhook URLs pointing to non-Discord hosts are rejected."""
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK):
+            with pytest.raises(ValueError, match="discord.com"):
+                notifier.send_discord_message(
+                    sample_games,
+                    webhook_url="https://evil.com/api/webhooks/123/token",
+                )
+
+    def test_raises_on_non_https_override_url(self, sample_games):
+        """User-supplied webhook URLs not using HTTPS are rejected."""
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK):
+            with pytest.raises(ValueError, match="HTTPS"):
+                notifier.send_discord_message(
+                    sample_games,
+                    webhook_url="http://discord.com/api/webhooks/123/token",
+                )
+
+    def test_raises_on_override_url_with_wrong_path(self, sample_games):
+        """User-supplied webhook URLs without /api/webhooks/ path are rejected."""
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK):
+            with pytest.raises(ValueError, match="/api/webhooks/"):
+                notifier.send_discord_message(
+                    sample_games,
+                    webhook_url="https://discord.com/not/a/webhook",
+                )
+
+    def test_discordapp_com_host_is_allowed(self, sample_games):
+        """discord.com and discordapp.com are both valid webhook hosts."""
+        alt_host_url = "https://discordapp.com/api/webhooks/123/token"
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message(sample_games, webhook_url=alt_host_url)
+
+        args, _ = mock_post.call_args
+        assert args[0] == alt_host_url


### PR DESCRIPTION
This pull request adds support for specifying a custom Discord webhook URL per request for notification endpoints, primarily to enable safe end-to-end (E2E) testing without altering global configuration. It introduces strict validation to prevent SSRF attacks by ensuring only legitimate Discord webhook URLs are accepted. The changes also update the notifier logic and tests to support and verify this override functionality.

**Discord Webhook Override and Validation**

* Added a `WebhookOverrideRequest` Pydantic model to accept an optional `webhook_url` in relevant API endpoints, with a validator that ensures only valid Discord webhook URLs are accepted, preventing SSRF attacks (`api.py`, `modules/notifier.py`). [[1]](diffhunk://#diff-1ed02c3495a2cbdfb7310b80b4a533d180f77b750ebf1e23a86d0d93e5872178R115-R145) [[2]](diffhunk://#diff-91904965bc8dcf8b915a29ee992f3dba72335df7bb65f7886cf9e1308ecab1dbR30-R58)
* Implemented the `validate_discord_webhook_url` function to check URL scheme, host, and path, only allowing `https://discord.com/api/webhooks/...` or `https://discordapp.com/api/webhooks/...` URLs (`modules/notifier.py`).

**Notifier Logic Enhancements**

* Updated `send_discord_message` to accept an optional `webhook_url` parameter, use it if provided (after validation), and ensure all internal logic (including logging and error handling) uses the effective webhook URL (`modules/notifier.py`). [[1]](diffhunk://#diff-91904965bc8dcf8b915a29ee992f3dba72335df7bb65f7886cf9e1308ecab1dbL54-R119) [[2]](diffhunk://#diff-91904965bc8dcf8b915a29ee992f3dba72335df7bb65f7886cf9e1308ecab1dbL128-R182) [[3]](diffhunk://#diff-91904965bc8dcf8b915a29ee992f3dba72335df7bb65f7886cf9e1308ecab1dbL153-R215)
* Updated API endpoints (`/notify/discord/resend` and `/check`) to accept and pass the webhook override to the notifier, and to validate the override via the new model (`api.py`). [[1]](diffhunk://#diff-1ed02c3495a2cbdfb7310b80b4a533d180f77b750ebf1e23a86d0d93e5872178L265-R303) [[2]](diffhunk://#diff-1ed02c3495a2cbdfb7310b80b4a533d180f77b750ebf1e23a86d0d93e5872178L281-R315) [[3]](diffhunk://#diff-1ed02c3495a2cbdfb7310b80b4a533d180f77b750ebf1e23a86d0d93e5872178L334-R368) [[4]](diffhunk://#diff-1ed02c3495a2cbdfb7310b80b4a533d180f77b750ebf1e23a86d0d93e5872178R378-R379) [[5]](diffhunk://#diff-1ed02c3495a2cbdfb7310b80b4a533d180f77b750ebf1e23a86d0d93e5872178L369-R405)

**Testing Improvements**

* Added and updated tests to verify the webhook override logic, ensure only valid Discord webhook URLs are accepted, and reject invalid or unsafe URLs. Tests also check that the correct URL is used in outbound requests (`tests/test_api.py`, `tests/test_notifier.py`). [[1]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79L161-R161) [[2]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R186-R198) [[3]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R298-R311) [[4]](diffhunk://#diff-b5924624ed68e598065cfbe32ab20afc4ee70db691a08ae7803d36084562931fR212-R282)

Closes #48 