### PR TITLE
Run only production pytest in E2E Jenkinsfile

### DIFF
--- a/tests/e2e/Jenkinsfile
+++ b/tests/e2e/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
           sh '''
             . .venv/bin/activate
             export API_BASE_URL="$API_BASE_URL"
-            pytest tests/e2e/test_production_smoke.py -v --tb=short --junitxml=junit.xml
+            pytest tests/e2e/test_production_smoke.py -v --tb=short --junitxml=junit.xml -o addopts='' -m production
           '''
         }
       }


### PR DESCRIPTION
Modify the Jenkins pipeline pytest command to ignore global addopts and execute only tests marked 'production'. Adds `-o addopts=''` to clear any configured addopts and `-m production` to select production smoke tests while preserving junit xml output.