### PR TITLE
chore: Add project board sync workflow and CLAUDE.md

### DIFF
--- a/.github/workflows/sync-project-status.yml
+++ b/.github/workflows/sync-project-status.yml
@@ -1,0 +1,86 @@
+name: Sync Issue Status with Project Board
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, closed]
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  projects: write
+
+env:
+  PROJECT_NUMBER: 2
+  PROJECT_OWNER: JulioMoralesB
+  STATUS_FIELD_ID: PVTSSF_lAHOBgvcQc4BR2svzg_jvuU
+  STATUS_IN_PROGRESS: 47fc9ee4
+  STATUS_IN_REVIEW: df73e18b
+  STATUS_DONE: 98236657
+
+jobs:
+  update-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move issue to In Progress (label added)
+        if: github.event_name == 'issues' && github.event.label.name == 'in-progress'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PROJECT_ID=$(gh project list --owner $PROJECT_OWNER --format json \
+            | jq -r --argjson n $PROJECT_NUMBER '.projects[] | select(.number == $n) | .id')
+          ITEM_ID=$(gh project item-add $PROJECT_NUMBER --owner $PROJECT_OWNER \
+            --url "${{ github.event.issue.html_url }}" --format json | jq -r '.id')
+          gh project item-edit --id "$ITEM_ID" \
+            --field-id $STATUS_FIELD_ID \
+            --project-id "$PROJECT_ID" \
+            --single-select-option-id $STATUS_IN_PROGRESS
+
+      - name: Move linked issue to In Review (PR opened)
+        if: >
+          github.event_name == 'pull_request' &&
+          (github.event.action == 'opened' || github.event.action == 'ready_for_review')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          PROJECT_ID=$(gh project list --owner $PROJECT_OWNER --format json \
+            | jq -r --argjson n $PROJECT_NUMBER '.projects[] | select(.number == $n) | .id')
+          echo "$PR_BODY" \
+            | grep -oiE '(closes?|fixes?|resolves?)\s+#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | while read ISSUE_NUM; do
+                ISSUE_URL="https://github.com/${{ github.repository }}/issues/$ISSUE_NUM"
+                ITEM_ID=$(gh project item-add $PROJECT_NUMBER --owner $PROJECT_OWNER \
+                  --url "$ISSUE_URL" --format json | jq -r '.id')
+                gh project item-edit --id "$ITEM_ID" \
+                  --field-id $STATUS_FIELD_ID \
+                  --project-id "$PROJECT_ID" \
+                  --single-select-option-id $STATUS_IN_REVIEW
+              done
+
+      - name: Move linked issue to Done (PR merged)
+        if: >
+          github.event_name == 'pull_request' &&
+          github.event.action == 'closed' &&
+          github.event.pull_request.merged == true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          PROJECT_ID=$(gh project list --owner $PROJECT_OWNER --format json \
+            | jq -r --argjson n $PROJECT_NUMBER '.projects[] | select(.number == $n) | .id')
+          echo "$PR_BODY" \
+            | grep -oiE '(closes?|fixes?|resolves?)\s+#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | while read ISSUE_NUM; do
+                ISSUE_URL="https://github.com/${{ github.repository }}/issues/$ISSUE_NUM"
+                ITEM_ID=$(gh project item-add $PROJECT_NUMBER --owner $PROJECT_OWNER \
+                  --url "$ISSUE_URL" --format json | jq -r '.id')
+                gh project item-edit --id "$ITEM_ID" \
+                  --field-id $STATUS_FIELD_ID \
+                  --project-id "$PROJECT_ID" \
+                  --single-select-option-id $STATUS_DONE
+              done

--- a/.github/workflows/sync-project-status.yml
+++ b/.github/workflows/sync-project-status.yml
@@ -2,7 +2,7 @@ name: Sync Issue Status with Project Board
 
 on:
   pull_request:
-    types: [opened, ready_for_review, closed]
+    types: [opened, edited, ready_for_review, reopened, closed]
   issues:
     types: [labeled]
 
@@ -23,6 +23,8 @@ env:
 jobs:
   update-status:
     runs-on: ubuntu-latest
+    # Skip fork PRs: GITHUB_TOKEN is read-only for forks and cannot write to the project board
+    if: github.event_name == 'issues' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Move issue to In Progress (label added)
         if: github.event_name == 'issues' && github.event.label.name == 'in-progress'
@@ -31,6 +33,7 @@ jobs:
         run: |
           PROJECT_ID=$(gh project list --owner $PROJECT_OWNER --format json \
             | jq -r --argjson n $PROJECT_NUMBER '.projects[] | select(.number == $n) | .id')
+          [ -z "$PROJECT_ID" ] && echo "ERROR: Project ID not found" && exit 1
           ITEM_ID=$(gh project item-add $PROJECT_NUMBER --owner $PROJECT_OWNER \
             --url "${{ github.event.issue.html_url }}" --format json | jq -r '.id')
           gh project item-edit --id "$ITEM_ID" \
@@ -48,6 +51,7 @@ jobs:
         run: |
           PROJECT_ID=$(gh project list --owner $PROJECT_OWNER --format json \
             | jq -r --argjson n $PROJECT_NUMBER '.projects[] | select(.number == $n) | .id')
+          [ -z "$PROJECT_ID" ] && echo "ERROR: Project ID not found" && exit 1
           echo "$PR_BODY" \
             | grep -oiE '(closes?|fixes?|resolves?)\s+#[0-9]+' \
             | grep -oE '[0-9]+' \
@@ -72,6 +76,7 @@ jobs:
         run: |
           PROJECT_ID=$(gh project list --owner $PROJECT_OWNER --format json \
             | jq -r --argjson n $PROJECT_NUMBER '.projects[] | select(.number == $n) | .id')
+          [ -z "$PROJECT_ID" ] && echo "ERROR: Project ID not found" && exit 1
           echo "$PR_BODY" \
             | grep -oiE '(closes?|fixes?|resolves?)\s+#[0-9]+' \
             | grep -oE '[0-9]+' \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# Free Games Notifier — Claude Instructions
+
+## Issue & Project Board Workflow
+
+When working on an issue, follow this lifecycle:
+
+1. **Al empezar a trabajar** en un issue:
+   - Añadir label `in-progress` al issue → el GitHub Action lo mueve a "In progress" en el board automáticamente.
+
+2. **Al crear un PR**:
+   - Incluir `Closes #N` (o `Fixes #N`) en el cuerpo del PR para que el Action detecte el issue vinculado y lo mueva a "In review".
+   - El formato del título del PR debe incluir `(#N)` para referencia, pero lo que mueve el board es `Closes #N` en el body.
+
+3. **Al hacer merge del PR**:
+   - El Action mueve automáticamente el issue a "Done".
+
+### Project Board (free-games-notifier)
+- Project number: 2
+- Owner: JulioMoralesB
+- Status field ID: `PVTSSF_lAHOBgvcQc4BR2svzg_jvuU`
+- Columns: Backlog → Ready → In progress → In review → Done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,15 @@
 
 When working on an issue, follow this lifecycle:
 
-1. **Al empezar a trabajar** en un issue:
-   - Añadir label `in-progress` al issue → el GitHub Action lo mueve a "In progress" en el board automáticamente.
+1. **When starting work** on an issue:
+   - Add the `in-progress` label → the GitHub Action moves it to "In progress" on the board automatically.
 
-2. **Al crear un PR**:
-   - Incluir `Closes #N` (o `Fixes #N`) en el cuerpo del PR para que el Action detecte el issue vinculado y lo mueva a "In review".
-   - El formato del título del PR debe incluir `(#N)` para referencia, pero lo que mueve el board es `Closes #N` en el body.
+2. **When creating a PR**:
+   - Include `Closes #N` (or `Fixes #N`) in the PR body so the Action detects the linked issue and moves it to "In review".
+   - The PR title should include `(#N)` for reference, but what triggers the board move is `Closes #N` in the body.
 
-3. **Al hacer merge del PR**:
-   - El Action mueve automáticamente el issue a "Done".
+3. **When the PR is merged**:
+   - The Action moves the issue to "Done" automatically.
 
 ### Project Board (free-games-notifier)
 - Project number: 2


### PR DESCRIPTION
## Summary

- GitHub Action (`.github/workflows/sync-project-status.yml`) that automatically syncs issue status with Project Board #2:
  - `in-progress` label added → moves to **In progress**
  - PR opened with `Closes #N` in the body → moves to **In review**
  - PR merged → moves to **Done**
- `CLAUDE.md` with issue lifecycle rules for Claude to follow in every session

## Test plan
- [ ] Verify the Action has the correct permissions (`projects: write`) on the first trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)