### PR TITLE
feat: Add rate limit handling and retries for Steam scraper (#85)

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,6 +14,13 @@ EPIC_GAMES_API_URL = os.getenv("EPIC_GAMES_API_URL", "https://store-site-backend
 # Steam Store search URL
 STEAM_SEARCH_URL = os.getenv("STEAM_SEARCH_URL", "https://store.steampowered.com/search/")
 
+# Minimum delay in milliseconds between Steam HTTP requests to avoid rate limiting
+_raw_steam_delay = os.getenv("STEAM_REQUEST_DELAY_MS")
+try:
+    STEAM_REQUEST_DELAY_MS = max(0, int(_raw_steam_delay)) if _raw_steam_delay not in (None, "") else 1500
+except ValueError:
+    STEAM_REQUEST_DELAY_MS = 1500
+
 # Discord Webhook URL (loaded from .env)
 DISCORD_WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL")
 

--- a/modules/scrapers/steam.py
+++ b/modules/scrapers/steam.py
@@ -57,6 +57,7 @@ def _steam_get(url: str, **kwargs) -> requests.Response:
     time.sleep(STEAM_REQUEST_DELAY_MS / 1000)
     response = requests.get(url, **kwargs)
     if response.status_code == 429:
+        response.close()
         raise _RateLimitedError(f"Rate limited by Steam (429) for {url}")
     return response
 

--- a/modules/scrapers/steam.py
+++ b/modules/scrapers/steam.py
@@ -2,22 +2,29 @@
 
 import logging
 import re
+import time
 from datetime import datetime, timezone
 from typing import Optional
 
 import requests
 from bs4 import BeautifulSoup
 
-from config import STEAM_SEARCH_URL
+from config import STEAM_REQUEST_DELAY_MS, STEAM_SEARCH_URL
 from modules.models import FreeGame
 from modules.retry import with_retry
 from modules.scrapers.base import BaseScraper
 
 logger = logging.getLogger(__name__)
 
+
+class _RateLimitedError(Exception):
+    pass
+
+
 _RETRYABLE_ERRORS = (
     requests.exceptions.Timeout,
     requests.exceptions.ConnectionError,
+    _RateLimitedError,
 )
 
 _HEADERS = {
@@ -43,6 +50,15 @@ _END_DATE_RE = re.compile(
     r"before\s+(\d{1,2})\s+(\w{3})\s+@\s+(\d{1,2}):(\d{2})(am|pm)",
     re.IGNORECASE,
 )
+
+
+def _steam_get(url: str, **kwargs) -> requests.Response:
+    """Sleep for STEAM_REQUEST_DELAY_MS, then GET url. Raises _RateLimitedError on HTTP 429."""
+    time.sleep(STEAM_REQUEST_DELAY_MS / 1000)
+    response = requests.get(url, **kwargs)
+    if response.status_code == 429:
+        raise _RateLimitedError(f"Rate limited by Steam (429) for {url}")
+    return response
 
 
 def _parse_steam_end_date(text: str) -> str:
@@ -78,14 +94,14 @@ class SteamScraper(BaseScraper):
         logger.info("Fetching free games from Steam. URL: %s", STEAM_SEARCH_URL)
         try:
             response = with_retry(
-                func=lambda: requests.get(
+                func=lambda: _steam_get(
                     STEAM_SEARCH_URL,
                     params=_SEARCH_PARAMS,
                     headers=_HEADERS,
                     timeout=10,
                 ),
                 max_attempts=4,
-                base_delay=1,
+                base_delay=2,
                 retryable_exceptions=_RETRYABLE_ERRORS,
                 description="Steam search fetch",
             )
@@ -167,11 +183,17 @@ class SteamScraper(BaseScraper):
     def _fetch_appdetails(self, appid: str) -> dict:
         """Fetch short_description and header_image from the Steam appdetails API."""
         try:
-            response = requests.get(
-                _APPDETAILS_URL,
-                params={"appids": appid, "cc": "US", "l": "english"},
-                headers=_HEADERS,
-                timeout=10,
+            response = with_retry(
+                func=lambda: _steam_get(
+                    _APPDETAILS_URL,
+                    params={"appids": appid, "cc": "US", "l": "english"},
+                    headers=_HEADERS,
+                    timeout=10,
+                ),
+                max_attempts=4,
+                base_delay=2,
+                retryable_exceptions=_RETRYABLE_ERRORS,
+                description=f"Steam appdetails (appid={appid})",
             )
             if response.status_code == 200:
                 data = response.json()
@@ -188,7 +210,13 @@ class SteamScraper(BaseScraper):
         on the store page. The time is in UTC when scraped without session cookies.
         """
         try:
-            response = requests.get(url, headers=_HEADERS, timeout=10)
+            response = with_retry(
+                func=lambda: _steam_get(url, headers=_HEADERS, timeout=10),
+                max_attempts=3,
+                base_delay=2,
+                retryable_exceptions=_RETRYABLE_ERRORS,
+                description=f"Steam end date ({url})",
+            )
             if response.status_code != 200:
                 return ""
             soup = BeautifulSoup(response.text, "html.parser")
@@ -203,11 +231,17 @@ class SteamScraper(BaseScraper):
     def _fetch_review_score(self, appid: str) -> Optional[str]:
         """Fetch user review summary label from the Steam reviews API."""
         try:
-            response = requests.get(
-                f"{_APPREVIEWS_URL}/{appid}",
-                params={"json": 1, "language": "all", "purchase_type": "all"},
-                headers=_HEADERS,
-                timeout=10,
+            response = with_retry(
+                func=lambda: _steam_get(
+                    f"{_APPREVIEWS_URL}/{appid}",
+                    params={"json": 1, "language": "all", "purchase_type": "all"},
+                    headers=_HEADERS,
+                    timeout=10,
+                ),
+                max_attempts=3,
+                base_delay=2,
+                retryable_exceptions=_RETRYABLE_ERRORS,
+                description=f"Steam review score (appid={appid})",
             )
             if response.status_code == 200:
                 data = response.json()

--- a/tests/test_steam_scrapper.py
+++ b/tests/test_steam_scrapper.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest.mock import patch, MagicMock
 
 import requests as req
@@ -106,6 +107,11 @@ def _multi_url_mock(appid="978520"):
 # ---------------------------------------------------------------------------
 
 class TestSteamScraper:
+    @pytest.fixture(autouse=True)
+    def no_sleep(self):
+        with patch("modules.scrapers.steam.time.sleep"):
+            yield
+
     def test_store_name(self):
         assert SteamScraper().store_name == "steam"
 
@@ -167,6 +173,24 @@ class TestSteamScraper:
                 games = SteamScraper().fetch_free_games()
 
         assert games == []
+
+    def test_returns_empty_on_rate_limit(self):
+        """HTTP 429 on search should retry then give up and return empty list."""
+        with patch("modules.scrapers.steam.requests.get") as mock_get:
+            mock_get.return_value = _mock_response(429)
+            with patch("modules.retry.time.sleep"):
+                games = SteamScraper().fetch_free_games()
+
+        assert games == []
+        assert mock_get.call_count == 4  # max_attempts=4
+
+    def test_request_delay_is_applied(self):
+        """Each Steam HTTP call must be preceded by a sleep."""
+        with patch("modules.scrapers.steam.requests.get", side_effect=_multi_url_mock()):
+            with patch("modules.scrapers.steam.time.sleep") as mock_sleep:
+                SteamScraper().fetch_free_games()
+
+        assert mock_sleep.call_count >= 4  # search + appdetails + reviews + end_date
 
     def test_gracefully_handles_failed_appdetails(self):
         """Game is still returned even if the appdetails call fails."""


### PR DESCRIPTION
## Summary

- Adds `STEAM_REQUEST_DELAY_MS` env var (default: `1500` ms) to throttle all Steam HTTP calls
- Introduces `_steam_get` helper that sleeps before every request and raises `_RateLimitedError` on HTTP 429
- Wraps `_fetch_appdetails`, `_fetch_end_date`, and `_fetch_review_score` with `with_retry` (exponential backoff, base 2s, up to 3–4 attempts), reusing the existing `with_retry` utility
- Updates the initial search fetch to also use `_steam_get` and the updated retry config

## Test plan

- [x] All existing Steam scraper tests pass
- [x] New test: HTTP 429 on search triggers 4 retries then returns empty list
- [x] New test: `time.sleep` is called at least once per Steam HTTP call (delay is applied)
- [x] Added `autouse` `no_sleep` fixture so tests run in ~0.18s instead of ~40s

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)