### PR TITLE
feat: Update storage schema to support multi-store (#87)

### DIFF
--- a/alembic/versions/0006_add_store_column.py
+++ b/alembic/versions/0006_add_store_column.py
@@ -42,9 +42,19 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Strip the single-segment store prefix so game_id values match the
-    # pre-0006 format.  REGEXP_REPLACE removes only the leading ``<store>:``
-    # token, leaving any further colons in the URL payload intact.
+    # Stripping all store prefixes would collapse ``epic:<url>`` and
+    # ``steam:<url>`` to the same bare URL, violating the UNIQUE constraint.
+    # The pre-0006 schema only stored Epic games, so non-epic rows are
+    # removed first.  This is intentionally destructive: downgrade means
+    # reverting to single-store support.
+    op.execute("""
+        DELETE FROM free_games.games
+        WHERE game_id ~ '^(steam|gog|humble):'
+    """)
+
+    # Strip the single-segment store prefix so remaining game_id values match
+    # the pre-0006 format.  REGEXP_REPLACE removes only the leading
+    # ``<store>:`` token, leaving any further colons in the URL intact.
     op.execute("""
         UPDATE free_games.games
         SET game_id = REGEXP_REPLACE(game_id, '^(epic|steam|gog|humble):', '')

--- a/alembic/versions/0006_add_store_column.py
+++ b/alembic/versions/0006_add_store_column.py
@@ -30,30 +30,21 @@ def upgrade() -> None:
     """)
 
     # 2. Migrate existing game_id values that don't already carry a store
-    #    prefix.  The only store stored so far is Epic, so all bare IDs get
-    #    the ``epic:`` prefix.  IDs that already contain a colon (e.g. a
-    #    future re-run) are left untouched.
+    #    prefix.  The only store stored so far is Epic, so all un-prefixed IDs
+    #    get the ``epic:`` prefix.  Match against known store prefixes rather
+    #    than any colon so existing URL-based IDs (https://...) are migrated.
     op.execute("""
         UPDATE free_games.games
         SET game_id = 'epic:' || game_id,
             store   = 'epic'
-        WHERE game_id NOT LIKE '%:%'
+        WHERE game_id !~ '^(epic|steam|gog|humble):'
     """)
 
 
 def downgrade() -> None:
-    # Strip the store prefix from game_id values so they match the pre-0006
-    # format, then drop the store column.
-    op.execute("""
-        UPDATE free_games.games
-        SET game_id = SPLIT_PART(game_id, ':', 2) || ':' ||
-                      SPLIT_PART(game_id, ':', 3)
-        WHERE game_id LIKE 'epic:%'
-          AND LENGTH(SPLIT_PART(game_id, ':', 2)) > 0
-    """)
-
-    # Simpler fallback: strip everything before the first colon for known
-    # stores that were added as a single-segment prefix.
+    # Strip the single-segment store prefix so game_id values match the
+    # pre-0006 format.  REGEXP_REPLACE removes only the leading ``<store>:``
+    # token, leaving any further colons in the URL payload intact.
     op.execute("""
         UPDATE free_games.games
         SET game_id = REGEXP_REPLACE(game_id, '^(epic|steam|gog|humble):', '')

--- a/alembic/versions/0006_add_store_column.py
+++ b/alembic/versions/0006_add_store_column.py
@@ -1,0 +1,66 @@
+"""Add store column to games table and migrate game_id to prefixed format.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-04-20
+
+Adds a ``store`` column (TEXT, NOT NULL, DEFAULT 'epic') to
+``free_games.games`` so that every row carries an explicit origin store.
+
+Also updates existing ``game_id`` values to use the ``<store>:<url>``
+prefixed format (e.g. ``epic:https://...``) so that IDs remain unique
+even when multiple stores share a similar URL structure.
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0006"
+down_revision: Union[str, None] = "0005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Add the store column with a safe default so existing rows are valid.
+    op.execute("""
+        ALTER TABLE free_games.games
+        ADD COLUMN IF NOT EXISTS store TEXT NOT NULL DEFAULT 'epic'
+    """)
+
+    # 2. Migrate existing game_id values that don't already carry a store
+    #    prefix.  The only store stored so far is Epic, so all bare IDs get
+    #    the ``epic:`` prefix.  IDs that already contain a colon (e.g. a
+    #    future re-run) are left untouched.
+    op.execute("""
+        UPDATE free_games.games
+        SET game_id = 'epic:' || game_id,
+            store   = 'epic'
+        WHERE game_id NOT LIKE '%:%'
+    """)
+
+
+def downgrade() -> None:
+    # Strip the store prefix from game_id values so they match the pre-0006
+    # format, then drop the store column.
+    op.execute("""
+        UPDATE free_games.games
+        SET game_id = SPLIT_PART(game_id, ':', 2) || ':' ||
+                      SPLIT_PART(game_id, ':', 3)
+        WHERE game_id LIKE 'epic:%'
+          AND LENGTH(SPLIT_PART(game_id, ':', 2)) > 0
+    """)
+
+    # Simpler fallback: strip everything before the first colon for known
+    # stores that were added as a single-segment prefix.
+    op.execute("""
+        UPDATE free_games.games
+        SET game_id = REGEXP_REPLACE(game_id, '^(epic|steam|gog|humble):', '')
+        WHERE game_id ~ '^(epic|steam|gog|humble):'
+    """)
+
+    op.execute("""
+        ALTER TABLE free_games.games
+        DROP COLUMN IF EXISTS store
+    """)

--- a/api.py
+++ b/api.py
@@ -42,7 +42,8 @@ from config import (
 class GameItem(BaseModel):
     """A free game as returned by the scraper."""
     title: str = Field(..., description="Name of the free game", examples=["Celeste"])
-    link: str = Field(..., description="Epic Games Store URL for the game")
+    store: str = Field("epic", description="Store identifier where the game is offered for free", examples=["epic", "steam"])
+    link: str = Field(..., description="Store URL for the game")
     end_date: str = Field(..., description="ISO-8601 timestamp when the free promotion ends", examples=["2024-01-31T15:00:00.000Z"])
     description: str = Field(..., description="Short description of the game")
     thumbnail: str = Field(..., description="URL to the game's thumbnail image")
@@ -159,12 +160,15 @@ def _to_game_item_dict(game) -> dict:
     if isinstance(game, FreeGame):
         return {
             "title": game.title,
+            "store": game.store,
             "link": game.url,
             "end_date": game.end_date,
             "description": game.description,
             "thumbnail": game.image_url,
         }
-    # Legacy dict format – pass through as-is for backward compatibility.
+    # Legacy dict format – ensure store key is present with a safe default.
+    if isinstance(game, dict) and "store" not in game:
+        return {**game, "store": "epic"}
     return game
 
 

--- a/modules/database.py
+++ b/modules/database.py
@@ -59,10 +59,14 @@ class FreeGamesDatabase:
         """Return a store-prefixed game ID to guarantee uniqueness across stores.
 
         Format: ``<store>:<url>``, e.g. ``epic:https://...`` or ``steam:https://...``.
-        If *url* is empty the raw store name is used as a fallback so the
-        NOT NULL constraint on game_id is never violated.
+        Raises :class:`ValueError` if either argument is empty so callers get a
+        loud failure instead of a non-unique or empty identifier.
         """
-        return f"{store}:{url}" if url else store
+        if not store or not url:
+            raise ValueError(
+                f"game_id requires non-empty store and url (got store={store!r}, url={url!r})"
+            )
+        return f"{store}:{url}"
 
     def get_games(self):
         """Retrieve all stored games from the database as a list of FreeGame objects."""
@@ -185,6 +189,11 @@ class FreeGamesDatabase:
                             store,
                         ))
                     else:
+                        if not game.url:
+                            logger.warning(
+                                f"Skipping game with missing url: {game.title}"
+                            )
+                            return
                         game_id = self._make_game_id(game.store, game.url)
                         cursor.execute("""
                             INSERT INTO games (game_id, title, link, description, thumbnail,

--- a/modules/database.py
+++ b/modules/database.py
@@ -54,6 +54,16 @@ class FreeGamesDatabase:
             logger.error(f"Failed to initialize database: {e}")
             raise
 
+    @staticmethod
+    def _make_game_id(store: str, url: str) -> str:
+        """Return a store-prefixed game ID to guarantee uniqueness across stores.
+
+        Format: ``<store>:<url>``, e.g. ``epic:https://...`` or ``steam:https://...``.
+        If *url* is empty the raw store name is used as a fallback so the
+        NOT NULL constraint on game_id is never violated.
+        """
+        return f"{store}:{url}" if url else store
+
     def get_games(self):
         """Retrieve all stored games from the database as a list of FreeGame objects."""
         try:
@@ -61,13 +71,14 @@ class FreeGamesDatabase:
                 with conn.cursor() as cursor:
                     cursor.execute("SET search_path TO free_games")
                     cursor.execute(
-                        "SELECT title, link, description, thumbnail, promotion_end_date, review_score FROM games"
+                        "SELECT title, link, description, thumbnail, "
+                        "promotion_end_date, review_score, store FROM games"
                     )
                     rows = cursor.fetchall()
                     games = [
                         FreeGame(
                             title=title,
-                            store="epic",
+                            store=store or "epic",
                             url=link,
                             image_url=thumbnail or "",
                             original_price=None,
@@ -76,7 +87,7 @@ class FreeGamesDatabase:
                             description=description or "",
                             review_score=review_score,
                         )
-                        for title, link, description, thumbnail, end_date, review_score in rows
+                        for title, link, description, thumbnail, end_date, review_score, store in rows
                     ]
                     logger.debug(f"Retrieved {len(games)} games from database.")
                     return games
@@ -85,7 +96,11 @@ class FreeGamesDatabase:
             raise
 
     def save_games(self, games):
-        """Save games to the database, upserting records on conflict by game_id (url)."""
+        """Save games to the database, upserting records on conflict by game_id.
+
+        ``game_id`` uses the ``<store>:<url>`` prefixed format so that records
+        from different stores never collide even if they share similar URLs.
+        """
         if not games:
             logger.warning("Attempted to save empty games list to database")
             return
@@ -94,23 +109,25 @@ class FreeGamesDatabase:
                 with conn.cursor() as cursor:
                     cursor.execute("SET search_path TO free_games")
                     for game in games:
-                        game_id = game.url
-                        if not game_id:
+                        if not game.url:
                             logger.warning(
                                 f"Skipping game with missing url: {game.title}"
                             )
                             continue
+                        game_id = self._make_game_id(game.store, game.url)
                         cursor.execute(
                             """
-                            INSERT INTO games (game_id, title, link, description, thumbnail, promotion_end_date, review_score)
-                            VALUES (%s, %s, %s, %s, %s, %s, %s)
+                            INSERT INTO games (game_id, title, link, description, thumbnail,
+                                               promotion_end_date, review_score, store)
+                            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                             ON CONFLICT (game_id) DO UPDATE SET
                                 title = EXCLUDED.title,
                                 link = EXCLUDED.link,
                                 description = EXCLUDED.description,
                                 thumbnail = EXCLUDED.thumbnail,
                                 promotion_end_date = EXCLUDED.promotion_end_date,
-                                review_score = EXCLUDED.review_score
+                                review_score = EXCLUDED.review_score,
+                                store = EXCLUDED.store
                             """,
                             (
                                 game_id,
@@ -120,6 +137,7 @@ class FreeGamesDatabase:
                                 game.image_url,
                                 game.end_date or None,
                                 game.review_score,
+                                game.store,
                             ),
                         )
                     conn.commit()
@@ -129,30 +147,60 @@ class FreeGamesDatabase:
             raise
     
     def insert_game(self, game):
-        """Insert a game record into the database."""
+        """Insert a game record into the database.
+
+        *game* may be a dict with legacy keys or a :class:`FreeGame` instance.
+        The ``game_id`` is derived using the ``<store>:<url>`` prefix format so
+        that records remain unique across stores.
+        """
         try:
             with psycopg2.connect(**self.conn_params) as conn:
                 with conn.cursor() as cursor:
-                    
+
                     # Set schema for this connection
                     cursor.execute("SET search_path to free_games")
 
-                    cursor.execute("""
-                        INSERT INTO games (game_id, title, link, description, thumbnail, promotion_end_date)
-                        VALUES (%s, %s, %s, %s, %s, %s)
-                        ON CONFLICT (game_id) DO NOTHING
-                    """, (
-                        game['game_id'],
-                        game['title'],
-                        game['link'],
-                        game['description'],
-                        game['thumbnail'],
-                        game['end_date']
-                    ))
+                    # Accept both dict (legacy) and FreeGame object.
+                    if isinstance(game, dict):
+                        store = game.get("store", "epic")
+                        url = game.get("link") or game.get("url") or ""
+                        game_id = self._make_game_id(store, url)
+                        cursor.execute("""
+                            INSERT INTO games (game_id, title, link, description, thumbnail,
+                                               promotion_end_date, store)
+                            VALUES (%s, %s, %s, %s, %s, %s, %s)
+                            ON CONFLICT (game_id) DO NOTHING
+                        """, (
+                            game_id,
+                            game.get("title"),
+                            url,
+                            game.get("description"),
+                            game.get("thumbnail"),
+                            game.get("end_date"),
+                            store,
+                        ))
+                    else:
+                        game_id = self._make_game_id(game.store, game.url)
+                        cursor.execute("""
+                            INSERT INTO games (game_id, title, link, description, thumbnail,
+                                               promotion_end_date, store)
+                            VALUES (%s, %s, %s, %s, %s, %s, %s)
+                            ON CONFLICT (game_id) DO NOTHING
+                        """, (
+                            game_id,
+                            game.title,
+                            game.url,
+                            game.description,
+                            game.image_url,
+                            game.end_date or None,
+                            game.store,
+                        ))
                     conn.commit()
-                    logger.info(f"Game '{game['title']}' inserted successfully.")
+                    title = game.get("title") if isinstance(game, dict) else game.title
+                    logger.info(f"Game '{title}' inserted successfully.")
         except Exception as e:
-            logger.error(f"Failed to insert game '{game['title']}': {e}")
+            title = game.get("title") if isinstance(game, dict) else getattr(game, "title", repr(game))
+            logger.error(f"Failed to insert game '{title}': {e}")
 
     def get_all_games(self):
         """Retrieve all game records from the database."""
@@ -219,18 +267,29 @@ class FreeGamesDatabase:
             logger.error(f"Failed to retrieve last notification from database: {e}")
             raise
 
-    def game_exists(self, game_id):
-        """Check if a game with the given game_id already exists in the database."""
+    def game_exists(self, game_id: str, store: str = "") -> bool:
+        """Check if a game with the given game_id already exists in the database.
+
+        *game_id* may be a plain URL **or** an already-prefixed ID
+        (``<store>:<url>``).  When *store* is provided and *game_id* does not
+        already carry a prefix the lookup is performed against the prefixed form.
+        """
         try:
             with psycopg2.connect(**self.conn_params) as conn:
                 with conn.cursor() as cursor:
-                    
+
                     # Set schema for this connection
                     cursor.execute("SET search_path to free_games")
 
-                    cursor.execute("SELECT 1 FROM games WHERE game_id = %s", (game_id,))
+                    # Build the prefixed key when needed.
+                    lookup_id = (
+                        self._make_game_id(store, game_id)
+                        if store and ":" not in game_id
+                        else game_id
+                    )
+                    cursor.execute("SELECT 1 FROM games WHERE game_id = %s", (lookup_id,))
                     exists = cursor.fetchone() is not None
-                    logger.debug(f"Game with ID '{game_id}' exists: {exists}")
+                    logger.debug(f"Game with ID '{lookup_id}' exists: {exists}")
                     return exists
         except Exception as e:
             logger.error(f"Failed to check if game exists: {e}")

--- a/modules/database.py
+++ b/modules/database.py
@@ -164,6 +164,11 @@ class FreeGamesDatabase:
                     if isinstance(game, dict):
                         store = game.get("store", "epic")
                         url = game.get("link") or game.get("url") or ""
+                        if not url:
+                            logger.warning(
+                                f"Skipping game with missing url: {game.get('title')}"
+                            )
+                            return
                         game_id = self._make_game_id(store, url)
                         cursor.execute("""
                             INSERT INTO games (game_id, title, link, description, thumbnail,
@@ -281,10 +286,12 @@ class FreeGamesDatabase:
                     # Set schema for this connection
                     cursor.execute("SET search_path to free_games")
 
-                    # Build the prefixed key when needed.
+                    # Build the prefixed key when needed.  Check for the
+                    # store prefix explicitly — plain URLs already contain ":"
+                    # (https://...) so a bare colon test would always skip this.
                     lookup_id = (
                         self._make_game_id(store, game_id)
-                        if store and ":" not in game_id
+                        if store and not game_id.startswith(f"{store}:")
                         else game_id
                     )
                     cursor.execute("SELECT 1 FROM games WHERE game_id = %s", (lookup_id,))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from modules import storage
+from modules.database import FreeGamesDatabase
 from modules.models import FreeGame
 
 
@@ -402,3 +403,101 @@ class TestFreeGamesDatabaseGetLastNotification:
         with patch("modules.database.psycopg2.connect", return_value=mock_conn):
             result = db.get_last_notification()
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests for FreeGamesDatabase._make_game_id
+# ---------------------------------------------------------------------------
+
+class TestMakeGameId:
+    def test_normal_case(self):
+        result = FreeGamesDatabase._make_game_id("epic", "https://store.epicgames.com/p/game")
+        assert result == "epic:https://store.epicgames.com/p/game"
+
+    def test_steam_prefix(self):
+        result = FreeGamesDatabase._make_game_id("steam", "https://store.steampowered.com/app/1")
+        assert result == "steam:https://store.steampowered.com/app/1"
+
+    def test_raises_on_empty_url(self):
+        with pytest.raises(ValueError):
+            FreeGamesDatabase._make_game_id("epic", "")
+
+    def test_raises_on_empty_store(self):
+        with pytest.raises(ValueError):
+            FreeGamesDatabase._make_game_id("", "https://example.com")
+
+    def test_raises_on_both_empty(self):
+        with pytest.raises(ValueError):
+            FreeGamesDatabase._make_game_id("", "")
+
+
+# ---------------------------------------------------------------------------
+# Tests for FreeGamesDatabase.game_exists
+# ---------------------------------------------------------------------------
+
+class TestGameExists:
+    def _make_db(self):
+        from modules.database import FreeGamesDatabase
+        db = FreeGamesDatabase.__new__(FreeGamesDatabase)
+        db.conn_params = {}
+        return db
+
+    def _mock_conn(self, exists: bool):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (1,) if exists else None
+        mock_cursor.__enter__ = lambda s: s
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_conn.__enter__ = lambda s: s
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        return mock_conn, mock_cursor
+
+    def _get_lookup_id(self, mock_cursor):
+        """Extract the game_id parameter from the SELECT execute call."""
+        select_call = next(
+            c for c in reversed(mock_cursor.execute.call_args_list)
+            if "SELECT" in c[0][0]
+        )
+        return select_call[0][1][0]
+
+    def test_plain_url_with_store_builds_prefixed_lookup(self):
+        db = self._make_db()
+        mock_conn, mock_cursor = self._mock_conn(True)
+        with patch("modules.database.psycopg2.connect", return_value=mock_conn):
+            result = db.game_exists("https://store.epicgames.com/p/game", store="epic")
+        assert result is True
+        assert self._get_lookup_id(mock_cursor) == "epic:https://store.epicgames.com/p/game"
+
+    def test_already_prefixed_id_is_not_double_prefixed(self):
+        db = self._make_db()
+        mock_conn, mock_cursor = self._mock_conn(False)
+        prefixed = "epic:https://store.epicgames.com/p/game"
+        with patch("modules.database.psycopg2.connect", return_value=mock_conn):
+            result = db.game_exists(prefixed, store="epic")
+        assert result is False
+        assert self._get_lookup_id(mock_cursor) == prefixed
+
+    def test_no_store_passes_game_id_verbatim(self):
+        db = self._make_db()
+        mock_conn, mock_cursor = self._mock_conn(True)
+        raw_id = "epic:https://store.epicgames.com/p/game"
+        with patch("modules.database.psycopg2.connect", return_value=mock_conn):
+            result = db.game_exists(raw_id)
+        assert result is True
+        assert self._get_lookup_id(mock_cursor) == raw_id
+
+    def test_steam_url_with_store_builds_steam_prefix(self):
+        db = self._make_db()
+        mock_conn, mock_cursor = self._mock_conn(True)
+        with patch("modules.database.psycopg2.connect", return_value=mock_conn):
+            db.game_exists("https://store.steampowered.com/app/730", store="steam")
+        assert self._get_lookup_id(mock_cursor) == "steam:https://store.steampowered.com/app/730"
+
+    def test_returns_false_when_game_not_found(self):
+        db = self._make_db()
+        mock_conn, _ = self._mock_conn(False)
+        with patch("modules.database.psycopg2.connect", return_value=mock_conn):
+            result = db.game_exists("epic:https://example.com")
+        assert result is False


### PR DESCRIPTION
## Summary

- Add Alembic migration `0006`: adds `store TEXT NOT NULL DEFAULT 'epic'` column to `free_games.games` and migrates existing `game_id` values to the `<store>:<url>` prefixed format (e.g. `steam:https://...`) to prevent cross-store collisions.
- Update `FreeGamesDatabase` to persist and read the `store` column, and use `_make_game_id()` to generate prefixed game IDs in `save_games()`, `insert_game()`, and `game_exists()`.
- Expose `store` field in the `GameItem` API response model so callers can see which store each game originates from.

## Test plan

- [ ] Run existing test suite — all 175 tests should pass
- [ ] Apply migration against a local/staging DB and verify `store` column is added and existing `game_id` values are prefixed with `epic:`
- [ ] Verify Epic games are saved and queried with `epic:<url>` game IDs
- [ ] Verify Steam games are saved with `steam:<url>` game IDs with no collisions
- [ ] Test `game_exists()` with both plain URL and prefixed ID formats
- [ ] Check the API response includes the `store` field

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)