### PR TITLE
feat(#88): Add ENABLED_STORES env var and scraper registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ DISCORD_WEBHOOK_URL=https://discordapp.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_TOK
 # Leave commented for default behavior
 # EPIC_GAMES_API_URL=https://store-site-backend-static.ak.epicgames.com/freeGamesPromotions
 
+# Optional: Comma-separated list of stores to scrape.
+# Supported values: epic, steam. Defaults to "epic" for backwards compatibility.
+# Examples: ENABLED_STORES=epic  |  ENABLED_STORES=epic,steam  |  ENABLED_STORES=steam
+# ENABLED_STORES=epic
+
 # Optional: Health Check Monitoring (Healthchecks.io, UptimeKuma, etc)
 # Set to your monitoring service ping URL to get alerts when notifier stops running
 # HEALTHCHECK_URL=https://healthchecks.io/ping/YOUR_UUID_HERE

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ docker run -d \
 |----------|----------|---------|-------------|
 | `DISCORD_WEBHOOK_URL` | ✅ Yes | - | Discord webhook URL for sending notifications |
 | `EPIC_GAMES_API_URL` | ❌ No | Official API | Epic Games Store API endpoint |
+| `ENABLED_STORES` | ❌ No | `epic` | Comma-separated list of stores to scrape. Supported: `epic`, `steam` (e.g. `epic,steam`) |
 | `HEALTHCHECK_URL` | ❌ No | - | Healthchecks.io or UptimeKuma ping URL |
 | `ENABLE_HEALTHCHECK` | ❌ No | `false` | Enable health check pings (`true`/`false`) |
 | `DB_HOST` | ❌ No | - | PostgreSQL host (leave empty to use file storage) |

--- a/config.py
+++ b/config.py
@@ -11,6 +11,11 @@ os.makedirs("data", exist_ok=True)
 # Epic Games API URL
 EPIC_GAMES_API_URL = os.getenv("EPIC_GAMES_API_URL", "https://store-site-backend-static.ak.epicgames.com/freeGamesPromotions")
 
+# Comma-separated list of store identifiers to fetch free games from (e.g. "epic,steam").
+# Defaults to "epic" for backwards compatibility. Unknown stores are ignored with a warning.
+_raw_enabled_stores = os.getenv("ENABLED_STORES", "epic")
+ENABLED_STORES = [s.strip().lower() for s in _raw_enabled_stores.split(",") if s.strip()]
+
 # Steam Store search URL
 STEAM_SEARCH_URL = os.getenv("STEAM_SEARCH_URL", "https://store.steampowered.com/search/")
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 from modules.notifier import send_discord_message
-from modules.scrapers import EpicGamesScraper
+from modules.scrapers import get_enabled_scrapers
 from modules.storage import load_previous_games, save_games, save_last_notification
 from modules.healthcheck import healthcheck
 from modules.database import FreeGamesDatabase
@@ -11,6 +11,7 @@ from config import (
     DB_NAME,
     DB_USER,
     DB_PASSWORD,
+    ENABLED_STORES,
     SCHEDULE_TIME,
     HEALTHCHECK_INTERVAL,
     TIMEZONE,
@@ -118,17 +119,28 @@ def _find_new_games(current_games, previous_games):
     return new_games
 
 def check_games():
-    
+
     """Main execution function that checks for new free games and sends Discord notification."""
     logging.info("Checking for new free games...")
 
-    try:
-        scraper = EpicGamesScraper()
-        current_games = scraper.fetch_free_games()
-        logging.info(f"Games obtained from scraper: {len(current_games)} game(s)")
-    except Exception as e:
-        logging.error(f"Failed to fetch games from scraper: {str(e)}")
-        return
+    scrapers = get_enabled_scrapers(ENABLED_STORES)
+    logging.info(
+        "Running %d enabled scraper(s): %s",
+        len(scrapers),
+        [s.store_name for s in scrapers],
+    )
+
+    current_games = []
+    for scraper in scrapers:
+        store = scraper.store_name
+        try:
+            store_games = scraper.fetch_free_games()
+            logging.info(f"Games obtained from {store} scraper: {len(store_games)} game(s)")
+            current_games.extend(store_games)
+        except Exception as e:
+            # Isolate failures so one broken store does not prevent others from running.
+            logging.error(f"Failed to fetch games from {store} scraper: {str(e)}")
+            continue
 
     if current_games == []:
         logging.error("No free games found or failed to fetch.")

--- a/modules/scrapers/__init__.py
+++ b/modules/scrapers/__init__.py
@@ -1,7 +1,54 @@
 """Game store scrapers package."""
 
+import logging
+from typing import Iterable
+
 from modules.scrapers.base import BaseScraper
 from modules.scrapers.epic import EpicGamesScraper
 from modules.scrapers.steam import SteamScraper
 
-__all__ = ["BaseScraper", "EpicGamesScraper", "SteamScraper"]
+logger = logging.getLogger(__name__)
+
+SCRAPER_REGISTRY: dict[str, type[BaseScraper]] = {
+    "epic": EpicGamesScraper,
+    "steam": SteamScraper,
+}
+
+
+def get_enabled_scrapers(enabled_stores: Iterable[str]) -> list[BaseScraper]:
+    """Instantiate scrapers for the given store identifiers.
+
+    Unknown store names are skipped with a warning so a misconfigured
+    ENABLED_STORES entry does not prevent the remaining scrapers from running.
+    If none of the requested stores are recognized, the Epic scraper is
+    returned as a safe default.
+    """
+    scrapers: list[BaseScraper] = []
+    for name in enabled_stores:
+        scraper_cls = SCRAPER_REGISTRY.get(name)
+        if scraper_cls is None:
+            logger.warning(
+                "Unknown store '%s' in ENABLED_STORES; known stores: %s",
+                name,
+                sorted(SCRAPER_REGISTRY.keys()),
+            )
+            continue
+        scrapers.append(scraper_cls())
+
+    if not scrapers:
+        logger.warning(
+            "No valid stores resolved from ENABLED_STORES=%s; defaulting to 'epic'.",
+            list(enabled_stores),
+        )
+        scrapers.append(EpicGamesScraper())
+
+    return scrapers
+
+
+__all__ = [
+    "BaseScraper",
+    "EpicGamesScraper",
+    "SteamScraper",
+    "SCRAPER_REGISTRY",
+    "get_enabled_scrapers",
+]

--- a/modules/scrapers/__init__.py
+++ b/modules/scrapers/__init__.py
@@ -23,8 +23,9 @@ def get_enabled_scrapers(enabled_stores: Iterable[str]) -> list[BaseScraper]:
     If none of the requested stores are recognized, the Epic scraper is
     returned as a safe default.
     """
+    stores = list(enabled_stores)
     scrapers: list[BaseScraper] = []
-    for name in enabled_stores:
+    for name in stores:
         scraper_cls = SCRAPER_REGISTRY.get(name)
         if scraper_cls is None:
             logger.warning(
@@ -38,7 +39,7 @@ def get_enabled_scrapers(enabled_stores: Iterable[str]) -> list[BaseScraper]:
     if not scrapers:
         logger.warning(
             "No valid stores resolved from ENABLED_STORES=%s; defaulting to 'epic'.",
-            list(enabled_stores),
+            stores,
         )
         scrapers.append(EpicGamesScraper())
 

--- a/tests/test_scraper_registry.py
+++ b/tests/test_scraper_registry.py
@@ -11,7 +11,7 @@ class TestScraperRegistry:
         assert SCRAPER_REGISTRY["epic"] is EpicGamesScraper
         assert SCRAPER_REGISTRY["steam"] is SteamScraper
 
-    def test_returns_only_epic_by_default(self):
+    def test_returns_only_epic_when_only_epic_enabled(self):
         scrapers = get_enabled_scrapers(["epic"])
 
         assert len(scrapers) == 1

--- a/tests/test_scraper_registry.py
+++ b/tests/test_scraper_registry.py
@@ -1,0 +1,52 @@
+from modules.scrapers import (
+    SCRAPER_REGISTRY,
+    EpicGamesScraper,
+    SteamScraper,
+    get_enabled_scrapers,
+)
+
+
+class TestScraperRegistry:
+    def test_registry_contains_epic_and_steam(self):
+        assert SCRAPER_REGISTRY["epic"] is EpicGamesScraper
+        assert SCRAPER_REGISTRY["steam"] is SteamScraper
+
+    def test_returns_only_epic_by_default(self):
+        scrapers = get_enabled_scrapers(["epic"])
+
+        assert len(scrapers) == 1
+        assert isinstance(scrapers[0], EpicGamesScraper)
+
+    def test_returns_both_when_both_enabled(self):
+        scrapers = get_enabled_scrapers(["epic", "steam"])
+
+        assert [s.store_name for s in scrapers] == ["epic", "steam"]
+        assert isinstance(scrapers[0], EpicGamesScraper)
+        assert isinstance(scrapers[1], SteamScraper)
+
+    def test_returns_only_steam_when_steam_enabled(self):
+        scrapers = get_enabled_scrapers(["steam"])
+
+        assert len(scrapers) == 1
+        assert isinstance(scrapers[0], SteamScraper)
+
+    def test_skips_unknown_stores_but_keeps_valid_ones(self, caplog):
+        with caplog.at_level("WARNING"):
+            scrapers = get_enabled_scrapers(["epic", "bogus"])
+
+        assert [s.store_name for s in scrapers] == ["epic"]
+        assert "bogus" in caplog.text
+
+    def test_falls_back_to_epic_when_all_unknown(self, caplog):
+        with caplog.at_level("WARNING"):
+            scrapers = get_enabled_scrapers(["nope"])
+
+        assert len(scrapers) == 1
+        assert isinstance(scrapers[0], EpicGamesScraper)
+
+    def test_falls_back_to_epic_when_empty(self, caplog):
+        with caplog.at_level("WARNING"):
+            scrapers = get_enabled_scrapers([])
+
+        assert len(scrapers) == 1
+        assert isinstance(scrapers[0], EpicGamesScraper)


### PR DESCRIPTION
## Summary
- Add `SCRAPER_REGISTRY` mapping (`epic` → `EpicGamesScraper`, `steam` → `SteamScraper`) plus a `get_enabled_scrapers()` helper that instantiates only the stores listed in `ENABLED_STORES`.
- Introduce the `ENABLED_STORES` env var (comma-separated, e.g. `epic,steam`), defaulting to `epic` for backwards compatibility. Unknown names are logged and skipped; if none resolve, Epic is used as a safe fallback.
- `main.py` now iterates over the active scrapers, isolating per-store failures so one broken source does not prevent the rest from running.
- Document the new variable in `.env.example` and the README.

Closes #88

## Test plan
- [x] `pytest tests/test_scraper_registry.py tests/test_scrapper.py tests/test_steam_scrapper.py -v` — 40 passed
- [x] Broader suite (excluding pre-existing `pytz`-dependent modules) — 90 passed
- [ ] Manual smoke: start service with `ENABLED_STORES=epic,steam` and confirm both scrapers run; with `ENABLED_STORES` unset confirm only Epic runs
- [ ] Manual smoke: set `ENABLED_STORES=bogus` and confirm warning log + fallback to Epic

🤖 Generated with [Claude Code](https://claude.com/claude-code)