### PR TITLE
fix: bypass Steam age-check and add multi-store Discord notifier support

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -24,6 +24,7 @@ services:
       - API_KEY=${API_KEY}
       - API_HOST=${API_HOST:-0.0.0.0}
       - API_PORT=${API_PORT:-8000}
+      - ENABLED_STORES=${ENABLED_STORES:-epic}
     image: free-games-notifier
     ports:
       - "${API_PORT:-8000}:${API_PORT:-8000}"

--- a/modules/notifier.py
+++ b/modules/notifier.py
@@ -118,50 +118,78 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
         validate_discord_webhook_url(effective_webhook_url)
     
     try:
+        _STORE_META = {
+            "epic": {
+                "name": "Epic Games Store",
+                "url": f"https://store.epicgames.com/{EPIC_GAMES_REGION}/free-games",
+                "color": 0x2ECC71,
+            },
+            "steam": {
+                "name": "Steam",
+                "url": "https://store.steampowered.com/search/?maxprice=free&specials=1",
+                "color": 0x1B2838,
+            },
+        }
+
         embeds = []
         for game in new_games:
             try:
-                end_date = datetime.strptime(game.end_date, "%Y-%m-%dT%H:%M:%S.%fZ")
-
-                dt_obj = pytz.utc.localize(end_date)
-                try:
-                    configured_tz = pytz.timezone(TIMEZONE)
-                except pytz.exceptions.UnknownTimeZoneError:
-                    logger.warning(
-                        "Unknown timezone %r — falling back to UTC. "
-                        "Set a valid IANA timezone in the TIMEZONE environment variable.",
-                        TIMEZONE,
-                    )
-                    configured_tz = pytz.utc
-                localized_end_date = dt_obj.astimezone(configured_tz)
-
-                # Compute UTC offset dynamically from the localized date (e.g. "UTC+05:30")
-                tz_offset_str = localized_end_date.strftime("%z")  # e.g. "-0600" or "+0530"
-                if tz_offset_str and len(tz_offset_str) == 5:
-                    sign = "+" if tz_offset_str[0] == "+" else "-"
-                    hours = tz_offset_str[1:3]
-                    minutes = tz_offset_str[3:5]
-                    utc_label = f"UTC{sign}{hours}:{minutes}"
+                if game.is_permanent or not game.end_date:
+                    formatted_end_date = None
                 else:
-                    utc_label = "UTC"
+                    try:
+                        end_date = datetime.strptime(game.end_date, "%Y-%m-%dT%H:%M:%S.%fZ")
+                    except ValueError:
+                        # Try without microseconds (e.g. Steam ISO strings)
+                        end_date = datetime.strptime(game.end_date, "%Y-%m-%dT%H:%M:%SZ")
 
-                # Format the final string, including the timezone name for context
-                formatted_end_date = f"{localized_end_date.strftime(DATE_FORMAT)} {utc_label} ({TIMEZONE})"
+                    dt_obj = pytz.utc.localize(end_date)
+                    try:
+                        configured_tz = pytz.timezone(TIMEZONE)
+                    except pytz.exceptions.UnknownTimeZoneError:
+                        logger.warning(
+                            "Unknown timezone %r — falling back to UTC. "
+                            "Set a valid IANA timezone in the TIMEZONE environment variable.",
+                            TIMEZONE,
+                        )
+                        configured_tz = pytz.utc
+                    localized_end_date = dt_obj.astimezone(configured_tz)
+
+                    # Compute UTC offset dynamically from the localized date (e.g. "UTC+05:30")
+                    tz_offset_str = localized_end_date.strftime("%z")  # e.g. "-0600" or "+0530"
+                    if tz_offset_str and len(tz_offset_str) == 5:
+                        sign = "+" if tz_offset_str[0] == "+" else "-"
+                        hours = tz_offset_str[1:3]
+                        minutes = tz_offset_str[3:5]
+                        utc_label = f"UTC{sign}{hours}:{minutes}"
+                    else:
+                        utc_label = "UTC"
+
+                    # Format the final string, including the timezone name for context
+                    formatted_end_date = f"{localized_end_date.strftime(DATE_FORMAT)} {utc_label} ({TIMEZONE})"
+
+                store_meta = _STORE_META.get(game.store, _STORE_META["epic"])
+                if formatted_end_date:
+                    footer_text = f"Finaliza el {formatted_end_date}"
+                elif game.is_permanent:
+                    footer_text = "Gratis de forma permanente"
+                else:
+                    footer_text = "Fecha de fin no disponible"
                 embeds.append(
                     {
                         "author": {
-                            "name": "Epic Games Store",
-                            "url": f"https://store.epicgames.com/{EPIC_GAMES_REGION}/free-games"
+                            "name": store_meta["name"],
+                            "url": store_meta["url"],
                         },
                         "title": game.title,
                         "url": game.url,
                         "description": game.description.replace("'", ""),
-                        "color": 0x2ECC71,
+                        "color": store_meta["color"],
                         "image": {
                             "url": game.image_url
                         },
                         "footer": {
-                            "text": f"Finaliza el {formatted_end_date}"
+                            "text": footer_text
                         }
                     }
                 )

--- a/modules/scrapers/steam.py
+++ b/modules/scrapers/steam.py
@@ -63,6 +63,12 @@ _END_DATE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Defined at module level to avoid recreating the dict on every _parse_steam_end_date call.
+_MONTH_MAP = {
+    "Jan": 1, "Feb": 2, "Mar": 3, "Apr": 4, "May": 5, "Jun": 6,
+    "Jul": 7, "Aug": 8, "Sep": 9, "Oct": 10, "Nov": 11, "Dec": 12,
+}
+
 
 def _steam_get(url: str, **kwargs) -> requests.Response:
     """Sleep for STEAM_REQUEST_DELAY_MS, then GET url. Raises _RateLimitedError on HTTP 429."""
@@ -76,20 +82,20 @@ def _steam_get(url: str, **kwargs) -> requests.Response:
 
 def _parse_steam_end_date(text: str) -> str:
     """Parse 'before DD Mon @ HH:MMam/pm' into an ISO-8601 UTC string."""
-    # Normalize all whitespace (including tabs, non-breaking, thin, etc.) to a single space
-    import re as _re
-    text = _re.sub(r"\s+", " ", text, flags=_re.UNICODE)
-    logger.info("Parsing Steam end date from text: %r", text[:200])
+    # Normalize all whitespace (including tabs, non-breaking, thin, etc.) to a single space.
+    # re is already imported at module level — inline 'import re as _re' was redundant.
+    text = re.sub(r"\s+", " ", text, flags=re.UNICODE)
+    logger.debug("Parsing Steam end date from text: %r", text[:200])
     m = _END_DATE_RE.search(text)
-    logger.info("Regex match for end date: %r", m.groups() if m else None)
-    
+    # Per-parse diagnostic logs use DEBUG so they don't spam production output.
+    logger.debug("Regex match for end date: %r", m.groups() if m else None)
+
     if not m:
         return ""
     day, month_str, hour, minute, ampm = m.groups()
     try:
-        MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
-                  'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
-        month = MONTHS.get(month_str)
+        # _MONTH_MAP is a module-level constant; avoids recreating the dict each call.
+        month = _MONTH_MAP.get(month_str)
         if not month:
             raise ValueError(f"Unknown month abbreviation: {month_str}")
         hour = int(hour)
@@ -97,14 +103,20 @@ def _parse_steam_end_date(text: str) -> str:
             hour += 12
         elif ampm.lower() == "am" and hour == 12:
             hour = 0
-        # Timezone should be obtained from TIMEZONE env var
-        local_tz = ZoneInfo(TIMEZONE)
+        # ZoneInfoNotFoundError is a subclass of KeyError, not ValueError, so it would
+        # escape the outer except and crash the scraper. Catch it here and fall back to
+        # UTC so a misconfigured TIMEZONE env var degrades gracefully.
+        try:
+            local_tz = ZoneInfo(TIMEZONE)
+        except KeyError:
+            logger.warning("Unknown timezone %r in _parse_steam_end_date — falling back to UTC.", TIMEZONE)
+            local_tz = timezone.utc
         now = datetime.now(tz=local_tz)
         dt = datetime(now.year, month, int(day), hour, int(minute), tzinfo=local_tz).astimezone(timezone.utc)
         if dt < now:
             dt = dt.replace(year=now.year + 1)
         formatted_dt = dt.isoformat().replace("+00:00", "Z")
-        logger.info("Parsed end date: %s (UTC)", formatted_dt)
+        logger.debug("Parsed end date: %s (UTC)", formatted_dt)
         return formatted_dt
     except ValueError:
         logger.error("Error parsing end date components: Day=%s, Month=%s, Hour=%s, Minute=%s, AM/PM=%s", day, month_str, hour, minute, ampm, exc_info=True)

--- a/modules/scrapers/steam.py
+++ b/modules/scrapers/steam.py
@@ -9,10 +9,12 @@ from typing import Optional
 import requests
 from bs4 import BeautifulSoup
 
-from config import STEAM_REQUEST_DELAY_MS, STEAM_SEARCH_URL
+from config import STEAM_REQUEST_DELAY_MS, STEAM_SEARCH_URL, TIMEZONE
 from modules.models import FreeGame
 from modules.retry import with_retry
 from modules.scrapers.base import BaseScraper
+
+from zoneinfo import ZoneInfo
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +36,16 @@ _HEADERS = {
         "Chrome/124.0.0.0 Safari/537.36"
     ),
     "Accept-Language": "en-US,en;q=0.9",
+}
+
+# Cookies that bypass Steam's age-check interstitial. Without these, mature-rated
+# store pages redirect to /agecheck/app/<id>/ which doesn't contain the discount
+# expiration text, so end_date can't be parsed.
+_AGE_CHECK_COOKIES = {
+    "birthtime": "470707201",
+    "mature_content": "1",
+    "lastagecheckage": "1-January-1985",
+    "wants_mature_content": "1",
 }
 
 _SEARCH_PARAMS = {
@@ -64,23 +76,38 @@ def _steam_get(url: str, **kwargs) -> requests.Response:
 
 def _parse_steam_end_date(text: str) -> str:
     """Parse 'before DD Mon @ HH:MMam/pm' into an ISO-8601 UTC string."""
+    # Normalize all whitespace (including tabs, non-breaking, thin, etc.) to a single space
+    import re as _re
+    text = _re.sub(r"\s+", " ", text, flags=_re.UNICODE)
+    logger.info("Parsing Steam end date from text: %r", text[:200])
     m = _END_DATE_RE.search(text)
+    logger.info("Regex match for end date: %r", m.groups() if m else None)
+    
     if not m:
         return ""
     day, month_str, hour, minute, ampm = m.groups()
     try:
-        month = datetime.strptime(month_str, "%b").month
+        MONTHS = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
+                  'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
+        month = MONTHS.get(month_str)
+        if not month:
+            raise ValueError(f"Unknown month abbreviation: {month_str}")
         hour = int(hour)
         if ampm.lower() == "pm" and hour != 12:
             hour += 12
         elif ampm.lower() == "am" and hour == 12:
             hour = 0
-        now = datetime.now(tz=timezone.utc)
-        dt = datetime(now.year, month, int(day), hour, int(minute), tzinfo=timezone.utc)
+        # Timezone should be obtained from TIMEZONE env var
+        local_tz = ZoneInfo(TIMEZONE)
+        now = datetime.now(tz=local_tz)
+        dt = datetime(now.year, month, int(day), hour, int(minute), tzinfo=local_tz).astimezone(timezone.utc)
         if dt < now:
             dt = dt.replace(year=now.year + 1)
-        return dt.isoformat()
+        formatted_dt = dt.isoformat().replace("+00:00", "Z")
+        logger.info("Parsed end date: %s (UTC)", formatted_dt)
+        return formatted_dt
     except ValueError:
+        logger.error("Error parsing end date components: Day=%s, Month=%s, Hour=%s, Minute=%s, AM/PM=%s", day, month_str, hour, minute, ampm, exc_info=True)
         return ""
 
 
@@ -212,7 +239,7 @@ class SteamScraper(BaseScraper):
         """
         try:
             response = with_retry(
-                func=lambda: _steam_get(url, headers=_HEADERS, timeout=10),
+                func=lambda: _steam_get(url, headers=_HEADERS, cookies=_AGE_CHECK_COOKIES, timeout=10),
                 max_attempts=3,
                 base_delay=2,
                 retryable_exceptions=_RETRYABLE_ERRORS,
@@ -221,10 +248,28 @@ class SteamScraper(BaseScraper):
             if response.status_code != 200:
                 return ""
             soup = BeautifulSoup(response.text, "html.parser")
+
+            # Try the dedicated discount quantity element first
             el = soup.select_one(".game_purchase_discount_quantity")
-            if not el:
-                return ""
-            return _parse_steam_end_date(el.text)
+            if el:
+                result = _parse_steam_end_date(el.text)
+                if result:
+                    return result
+                logger.warning(
+                    "Found .game_purchase_discount_quantity but could not parse end date. "
+                    "Text: %r | URL: %s",
+                    el.text[:200],
+                    url,
+                )
+
+            # Fall back to searching the entire page text — handles cases where
+            # Steam renders the element via JS or uses a different CSS class.
+            result = _parse_steam_end_date(soup.get_text(" "))
+            if result:
+                return result
+
+            logger.warning("Could not find promotion end date on Steam page: %s", url)
+            return ""
         except Exception as e:
             logger.warning("Failed to fetch end date from %s: %s", url, e)
             return ""

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock
 import requests as requests_lib
 
 from modules import notifier
+from modules.models import FreeGame
 
 
 VALID_WEBHOOK = "https://discord.com/api/webhooks/123456789/token_abc"
@@ -219,6 +220,51 @@ class TestSendDiscordMessage:
         with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK):
             with pytest.raises(ValueError):
                 notifier.send_discord_message([bad_game])
+
+    def test_embed_footer_unknown_end_date_when_empty_and_not_permanent(self):
+        """Games with no end_date and is_permanent=False show a 'not available' message."""
+        import dataclasses
+        game = dataclasses.replace(
+            FreeGame(
+                title="Steam Game",
+                store="steam",
+                url="https://store.steampowered.com/app/123/",
+                image_url="https://example.com/img.jpg",
+                original_price="$9.99",
+                end_date="",
+                is_permanent=False,
+                description="",
+            )
+        )
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message([game])
+
+        _, kwargs = mock_post.call_args
+        footer = kwargs["json"]["embeds"][0]["footer"]["text"]
+        assert footer == "Fecha de fin no disponible"
+
+    def test_embed_footer_permanent_game(self):
+        """Games with is_permanent=True show the permanent promotion message."""
+        game = FreeGame(
+            title="Free Forever Game",
+            store="epic",
+            url="https://store.epicgames.com/p/free-forever",
+            image_url="https://example.com/img.jpg",
+            original_price=None,
+            end_date="",
+            is_permanent=True,
+            description="",
+        )
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message([game])
+
+        _, kwargs = mock_post.call_args
+        footer = kwargs["json"]["embeds"][0]["footer"]["text"]
+        assert footer == "Gratis de forma permanente"
 
 
 class TestSendDiscordMessageWebhookOverride:

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -223,18 +223,16 @@ class TestSendDiscordMessage:
 
     def test_embed_footer_unknown_end_date_when_empty_and_not_permanent(self):
         """Games with no end_date and is_permanent=False show a 'not available' message."""
-        import dataclasses
-        game = dataclasses.replace(
-            FreeGame(
-                title="Steam Game",
-                store="steam",
-                url="https://store.steampowered.com/app/123/",
-                image_url="https://example.com/img.jpg",
-                original_price="$9.99",
-                end_date="",
-                is_permanent=False,
-                description="",
-            )
+        # dataclasses.replace with no replacements is a no-op; use FreeGame() directly.
+        game = FreeGame(
+            title="Steam Game",
+            store="steam",
+            url="https://store.steampowered.com/app/123/",
+            image_url="https://example.com/img.jpg",
+            original_price="$9.99",
+            end_date="",
+            is_permanent=False,
+            description="",
         )
         with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
              patch("modules.notifier.requests.post") as mock_post:

--- a/tests/test_steam_scrapper.py
+++ b/tests/test_steam_scrapper.py
@@ -1,9 +1,41 @@
 import pytest
 from unittest.mock import patch, MagicMock
+from datetime import datetime as _real_datetime, timezone as _utc_tz
 
 import requests as req
 
 from modules.scrapers.steam import SteamScraper, _parse_steam_end_date
+
+
+class _FakeDatetime(_real_datetime):
+    """Pins datetime.now() to 2026-01-01 UTC for deterministic year-rollover tests.
+
+    _parse_steam_end_date uses datetime.now() to decide whether the parsed promo
+    date has already passed and should roll over to next year. Without pinning 'now',
+    any test that asserts a specific year (e.g. "2026-04-23") breaks as soon as the
+    promo date passes in real time. _FakeDatetime is a subclass so the datetime()
+    constructor used in the same function still works normally.
+    """
+    @classmethod
+    def now(cls, tz=None):
+        return _real_datetime(2026, 1, 1, tzinfo=tz if tz is not None else _utc_tz)
+
+
+@pytest.fixture
+def freeze_steam_now():
+    """Pin datetime.now() and TIMEZONE for deterministic timestamp assertions.
+
+    Two patches are needed together:
+    - TIMEZONE → "UTC": _parse_steam_end_date converts local time to UTC using the
+      configured timezone. Without this pin, assertions on specific timestamps break
+      on any host not running in UTC.
+    - datetime → _FakeDatetime: the year-rollover logic uses datetime.now() to decide
+      whether to advance to next year. Without a pinned 'now', tests asserting a
+      specific year break as soon as the promo date passes in real time.
+    """
+    with patch("modules.scrapers.steam.datetime", _FakeDatetime), \
+         patch("modules.scrapers.steam.TIMEZONE", "UTC"):
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +147,7 @@ class TestSteamScraper:
     def test_store_name(self):
         assert SteamScraper().store_name == "steam"
 
-    def test_returns_free_game(self):
+    def test_returns_free_game(self, freeze_steam_now):
         with patch("modules.scrapers.steam.requests.get", side_effect=_multi_url_mock()):
             games = SteamScraper().fetch_free_games()
 
@@ -301,7 +333,7 @@ class TestSteamScraper:
         assert len(games) == 1
         assert games[0].end_date == ""
 
-    def test_end_date_falls_back_to_full_page_text(self):
+    def test_end_date_falls_back_to_full_page_text(self, freeze_steam_now):
         """If .game_purchase_discount_quantity is absent, the date is found in the page body."""
         store_page_no_element = """<html><body>
             <div class="game_purchase_action">
@@ -328,22 +360,22 @@ class TestSteamScraper:
 
 
 class TestParseSteamEndDate:
-    def test_parses_am_time(self):
+    def test_parses_am_time(self, freeze_steam_now):
         text = "Free to keep when you get it before 23 Apr @ 10:00am. Some limitations apply."
         result = _parse_steam_end_date(text)
         assert result.startswith("2026-04-23T10:00:00")
 
-    def test_parses_pm_time(self):
+    def test_parses_pm_time(self, freeze_steam_now):
         text = "Free to keep when you get it before 5 Jun @ 2:00pm."
         result = _parse_steam_end_date(text)
         assert "T14:00:00" in result
 
-    def test_parses_noon(self):
+    def test_parses_noon(self, freeze_steam_now):
         text = "before 1 May @ 12:00pm"
         result = _parse_steam_end_date(text)
         assert "T12:00:00" in result
 
-    def test_parses_midnight(self):
+    def test_parses_midnight(self, freeze_steam_now):
         text = "before 1 May @ 12:00am"
         result = _parse_steam_end_date(text)
         assert "T00:00:00" in result
@@ -354,7 +386,7 @@ class TestParseSteamEndDate:
     def test_returns_empty_on_empty_string(self):
         assert _parse_steam_end_date("") == ""
 
-    def test_handles_non_breaking_spaces(self):
+    def test_handles_non_breaking_spaces(self, freeze_steam_now):
         """Steam HTML uses U+00A0 non-breaking spaces which look identical in logs."""
         text = "Free\u00a0to\u00a0keep\u00a0when\u00a0you\u00a0get\u00a0it\u00a0before\u00a023\u00a0Apr\u00a0@\u00a010:00am.\t\t\tSome limitations apply. (?)"
         result = _parse_steam_end_date(text)

--- a/tests/test_steam_scrapper.py
+++ b/tests/test_steam_scrapper.py
@@ -301,6 +301,31 @@ class TestSteamScraper:
         assert len(games) == 1
         assert games[0].end_date == ""
 
+    def test_end_date_falls_back_to_full_page_text(self):
+        """If .game_purchase_discount_quantity is absent, the date is found in the page body."""
+        store_page_no_element = """<html><body>
+            <div class="game_purchase_action">
+              <p>Free to keep when you get it before 23 Apr @ 10:00am. Some limitations apply.</p>
+            </div>
+        </body></html>"""
+
+        def side_effect(url, **kwargs):
+            if "search" in url:
+                return _mock_response(200, text=_make_search_html())
+            if "appdetails" in url:
+                return _mock_response(200, json_data=_make_appdetails_response("978520"))
+            if "appreviews" in url:
+                return _mock_response(200, json_data=_make_appreviews_response())
+            if "store.steampowered.com/app/" in url:
+                return _mock_response(200, text=store_page_no_element)
+            return _mock_response(404)
+
+        with patch("modules.scrapers.steam.requests.get", side_effect=side_effect):
+            games = SteamScraper().fetch_free_games()
+
+        assert len(games) == 1
+        assert "2026-04-23T10:00:00" in games[0].end_date
+
 
 class TestParseSteamEndDate:
     def test_parses_am_time(self):
@@ -328,3 +353,9 @@ class TestParseSteamEndDate:
 
     def test_returns_empty_on_empty_string(self):
         assert _parse_steam_end_date("") == ""
+
+    def test_handles_non_breaking_spaces(self):
+        """Steam HTML uses U+00A0 non-breaking spaces which look identical in logs."""
+        text = "Free\u00a0to\u00a0keep\u00a0when\u00a0you\u00a0get\u00a0it\u00a0before\u00a023\u00a0Apr\u00a0@\u00a010:00am.\t\t\tSome limitations apply. (?)"
+        result = _parse_steam_end_date(text)
+        assert result.startswith("2026-04-23T10:00:00")


### PR DESCRIPTION
## Summary
- **Steam age-check bypass**: mature-rated pages (NineHells, Cthulhu DLC) were redirecting to `/agecheck/app/<id>/` which contains no discount expiration text — adding age-check cookies prevents the redirect and allows the end date to be parsed correctly
- **Steam end date fallback**: if `.game_purchase_discount_quantity` is absent, the scraper now falls back to scanning full page text; also normalizes non-breaking spaces before regex matching
- **Multi-store Discord embed**: per-store author name, URL, and embed color; notifier now handles missing `end_date` and `is_permanent=True` games gracefully in the footer
- **compose.yaml**: added `ENABLED_STORES` default value

## Test plan
- [ ] Verify NineHells and Cthulhu DLC return a non-empty `end_date` on next scrape run
- [ ] Verify Discord embeds show correct store branding (Epic green vs Steam dark)
- [ ] Verify footer shows "Fecha de fin no disponible" when `end_date` is empty
- [ ] Verify footer shows "Gratis de forma permanente" for permanent games
- [ ] Run unit tests: `pytest tests/test_notifier.py tests/test_steam_scrapper.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)