### PR TITLE
feat(#108): show correct store per game in dashboard

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -191,16 +191,7 @@ export default function App() {
       </main>
 
       <footer className="footer">
-        <p>
-          {t.footerText}{' '}
-          <a
-            href="https://www.epicgames.com/store/free-games"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {t.footerEpicGamesLink}
-          </a>
-        </p>
+        <p>{t.footerText}</p>
       </footer>
     </div>
   )

--- a/dashboard/src/components/GameCard.tsx
+++ b/dashboard/src/components/GameCard.tsx
@@ -4,6 +4,15 @@ import { useTranslation } from '../i18n'
 import type { Locale } from '../i18n/translations'
 import { localeBcp47 } from '../i18n/translations'
 
+const STORE_META: Record<string, { label: string; icon: string }> = {
+  epic:  { label: 'Epic Games', icon: '🏪' },
+  steam: { label: 'Steam',      icon: '🎮' },
+}
+
+function getStoreMeta(store: string) {
+  return STORE_META[store] ?? { label: store, icon: '🏪' }
+}
+
 interface Props {
   game: GameItem
 }
@@ -28,6 +37,7 @@ export default function GameCard({ game }: Props) {
   const [imgError, setImgError] = useState(false)
 
   const isPastPromotion = new Date(game.end_date) < new Date()
+  const storeMeta = getStoreMeta(game.store)
 
   return (
     <article className="card">
@@ -66,7 +76,7 @@ export default function GameCard({ game }: Props) {
               {formatDate(game.end_date, locale)}
             </span>
           </div>
-          <span className="card-store">{t.epicGamesStore}</span>
+          <span className="card-store">{storeMeta.icon} {storeMeta.label}</span>
         </div>
       </div>
 
@@ -77,7 +87,7 @@ export default function GameCard({ game }: Props) {
           target="_blank"
           rel="noopener noreferrer"
         >
-          {t.viewOnEpicGames}
+          {t.viewOnStore(storeMeta.label)}
         </a>
       </div>
     </article>

--- a/dashboard/src/i18n/translations.ts
+++ b/dashboard/src/i18n/translations.ts
@@ -23,8 +23,7 @@ export interface Translations {
   // GameCard
   wasFreeUntil: string
   freeUntil: string
-  epicGamesStore: string
-  viewOnEpicGames: string
+  viewOnStore: (storeName: string) => string
 
   // Pagination
   paginationNavAriaLabel: string
@@ -34,7 +33,6 @@ export interface Translations {
 
   // Footer
   footerText: string
-  footerEpicGamesLink: string
 
   // Language selector
   languageLabel: string
@@ -63,8 +61,7 @@ const en: Translations = {
   // GameCard
   wasFreeUntil: 'Was free until',
   freeUntil: 'Free until',
-  epicGamesStore: '🏪 Epic Games',
-  viewOnEpicGames: 'View on Epic Games →',
+  viewOnStore: (storeName) => `View on ${storeName} →`,
 
   // Pagination
   paginationNavAriaLabel: 'Pagination',
@@ -73,8 +70,7 @@ const en: Translations = {
   pageN: (n) => `Page ${n}`,
 
   // Footer
-  footerText: 'Free Games Notifier — Game history dashboard · Data from',
-  footerEpicGamesLink: 'Epic Games',
+  footerText: 'Free Games Notifier — Game history dashboard',
 
   // Language selector
   languageLabel: 'Language',
@@ -103,8 +99,7 @@ const es: Translations = {
   // GameCard
   wasFreeUntil: 'Estuvo gratis hasta el',
   freeUntil: 'Gratis hasta el',
-  epicGamesStore: '🏪 Epic Games',
-  viewOnEpicGames: 'Ver en Epic Games →',
+  viewOnStore: (storeName) => `Ver en ${storeName} →`,
 
   // Pagination
   paginationNavAriaLabel: 'Paginación',
@@ -113,8 +108,7 @@ const es: Translations = {
   pageN: (n) => `Página ${n}`,
 
   // Footer
-  footerText: 'Free Games Notifier — Panel de historial de juegos · Datos de',
-  footerEpicGamesLink: 'Epic Games',
+  footerText: 'Free Games Notifier — Panel de historial de juegos',
 
   // Language selector
   languageLabel: 'Idioma',

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -4,6 +4,7 @@ export interface GameItem {
   end_date: string;
   description: string;
   thumbnail: string;
+  store: string;
 }
 
 export interface GamesHistoryResponse {


### PR DESCRIPTION
## Summary
- `GameItem` type now includes `store: string` to match the API response
- `GameCard` derives the store badge and link text from `game.store` instead of hardcoding Epic branding
- Epic → 🏪 Epic Games, Steam → 🎮 Steam, unknown store → icon + raw value (safe fallback)
- `viewOnEpicGames` replaced by `viewOnStore(storeName)` in both `en` and `es` translations
- Footer simplified — removed hardcoded Epic Games link

## Test plan
- [x] Build passes (`tsc && vite build`) with no type errors
- [ ] Verify dashboard shows "🏪 Epic Games" badge on Epic games and "🎮 Steam" on Steam games
- [ ] Verify "Ver en Steam →" / "View on Steam →" link text on Steam cards (both locales)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)