### PR TITLE
feat(#112): localize Discord notification text based on LOCALE

### DIFF
--- a/modules/notifier.py
+++ b/modules/notifier.py
@@ -10,6 +10,66 @@ from modules.retry import with_retry
 import logging
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Locale-aware strings
+# ---------------------------------------------------------------------------
+
+_TRANSLATIONS = {
+    "en": {
+        "ends_on": "Ends on",
+        "permanently_free": "Permanently free",
+        "end_date_unavailable": "End date unavailable",
+        "user_reviews": "💬 User Reviews:",
+        "new_free_game": "**New Free Game on {store}! 🎮**\n",
+        "new_free_games": "**New Free Games! 🎮**\n",
+        "review_labels": {
+            "overwhelmingly positive": "Overwhelmingly Positive",
+            "very positive": "Very Positive",
+            "mostly positive": "Mostly Positive",
+            "positive": "Positive",
+            "mixed": "Mixed",
+            "mostly negative": "Mostly Negative",
+            "negative": "Negative",
+            "very negative": "Very Negative",
+            "overwhelmingly negative": "Overwhelmingly Negative",
+            "no user reviews": "No user reviews",
+        },
+    },
+    "es": {
+        "ends_on": "Finaliza el",
+        "permanently_free": "Gratis de forma permanente",
+        "end_date_unavailable": "Fecha de fin no disponible",
+        "user_reviews": "💬 Opiniones de usuarios:",
+        "new_free_game": "**¡Nuevo Juego Gratis en {store}! 🎮**\n",
+        "new_free_games": "**¡Nuevos Juegos Gratis! 🎮**\n",
+        "review_labels": {
+            "overwhelmingly positive": "Extremadamente Positivo",
+            "very positive": "Muy Positivo",
+            "mostly positive": "Mayormente Positivo",
+            "positive": "Positivo",
+            "mixed": "Mixto",
+            "mostly negative": "Mayormente Negativo",
+            "negative": "Negativo",
+            "very negative": "Muy Negativo",
+            "overwhelmingly negative": "Extremadamente Negativo",
+            "no user reviews": "Sin opiniones de usuarios",
+        },
+    },
+}
+
+
+def _get_lang(locale_str: str) -> str:
+    """Derive a two-letter language code from a LOCALE string (e.g. 'es_MX.UTF-8' → 'es')."""
+    if locale_str:
+        lang = locale_str.split("_")[0].split("-")[0].lower()
+        if lang in _TRANSLATIONS:
+            return lang
+    return "en"
+
+
+_LANG = _get_lang(LOCALE)
+_T = _TRANSLATIONS[_LANG]
+
 _DISCORD_RETRYABLE = (
     requests.exceptions.Timeout,
     requests.exceptions.ConnectionError,
@@ -172,11 +232,11 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
 
                 store_meta = _STORE_META.get(game.store, _STORE_META["epic"])
                 if formatted_end_date:
-                    footer_text = f"Finaliza el {formatted_end_date}"
+                    footer_text = f"{_T['ends_on']} {formatted_end_date}"
                 elif game.is_permanent:
-                    footer_text = "Gratis de forma permanente"
+                    footer_text = _T["permanently_free"]
                 else:
-                    footer_text = "Fecha de fin no disponible"
+                    footer_text = _T["end_date_unavailable"]
 
                 embed = {
                     "author": {
@@ -207,10 +267,10 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
                         "very negative": "⛔",
                         "overwhelmingly negative": "💀",
                     }
-                    emoji = _REVIEW_EMOJIS.get(game.review_score.lower(), "🎮")
-                    embed["fields"] = [
-                        {"name": "💬 User Reviews:", "value": f"{game.review_score} {emoji}", "inline": True}
-                    ]
+                    key = game.review_score.lower()
+                    emoji = _REVIEW_EMOJIS.get(key, "🎮")
+                    label = _T["review_labels"].get(key, game.review_score)
+                    embed["description"] += f"\n\n{_T['user_reviews']} {label} {emoji}"
                 embeds.append(embed)
             except (AttributeError, ValueError) as e:
                 logger.error(f"Error processing game data for embed: {str(e)} | Game data: {game}")
@@ -220,9 +280,9 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
         if len(stores_in_batch) == 1:
             store_key = next(iter(stores_in_batch))
             store_name = _STORE_META.get(store_key, _STORE_META["epic"])["name"]
-            content = f"**¡Nuevo Juego Gratis en {store_name}! 🎮**\n"
+            content = _T["new_free_game"].format(store=store_name)
         else:
-            content = "**¡Nuevos Juegos Gratis! 🎮**\n"
+            content = _T["new_free_games"]
 
         data = {
             "content": content,

--- a/modules/notifier.py
+++ b/modules/notifier.py
@@ -270,7 +270,7 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
                     key = game.review_score.lower()
                     emoji = _REVIEW_EMOJIS.get(key, "🎮")
                     label = _T["review_labels"].get(key, game.review_score)
-                    embed["description"] += f"\n\n{_T['user_reviews']} {label} {emoji}"
+                    embed["description"] += f"\n\n{_T['user_reviews']}\n{label} {emoji}\n\n"
                 embeds.append(embed)
             except (AttributeError, ValueError) as e:
                 logger.error(f"Error processing game data for embed: {str(e)} | Game data: {game}")

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -412,7 +412,9 @@ class TestSendDiscordMessage:
             is_permanent=False,
             description="",
         )
+        es_t = notifier._TRANSLATIONS["es"]
         with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier._T", es_t), \
              patch("modules.notifier.requests.post") as mock_post:
             mock_post.return_value = self._make_response(204)
             notifier.send_discord_message([game])
@@ -433,7 +435,9 @@ class TestSendDiscordMessage:
             is_permanent=True,
             description="",
         )
+        es_t = notifier._TRANSLATIONS["es"]
         with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier._T", es_t), \
              patch("modules.notifier.requests.post") as mock_post:
             mock_post.return_value = self._make_response(204)
             notifier.send_discord_message([game])

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -13,6 +13,23 @@ VALID_WEBHOOK = "https://discord.com/api/webhooks/123456789/token_abc"
 # Tests for _get_safe_webhook_identifier
 # ---------------------------------------------------------------------------
 
+class TestGetLang:
+    def test_returns_en_for_english_locale(self):
+        assert notifier._get_lang("en_US.UTF-8") == "en"
+
+    def test_returns_es_for_spanish_locale(self):
+        assert notifier._get_lang("es_MX.UTF-8") == "es"
+
+    def test_returns_es_for_spain_locale(self):
+        assert notifier._get_lang("es_ES.UTF-8") == "es"
+
+    def test_falls_back_to_en_for_unsupported_locale(self):
+        assert notifier._get_lang("de_DE.UTF-8") == "en"
+
+    def test_falls_back_to_en_for_empty_string(self):
+        assert notifier._get_lang("") == "en"
+
+
 class TestGetSafeWebhookIdentifier:
     def test_redacts_token_from_discord_url(self):
         result = notifier._get_safe_webhook_identifier(VALID_WEBHOOK)
@@ -96,14 +113,16 @@ class TestSendDiscordMessage:
         assert payload["embeds"][0]["image"]["url"] == sample_games[0].image_url
 
     def test_embed_footer_contains_end_date_prefix(self, sample_games):
+        en_t = notifier._TRANSLATIONS["en"]
         with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier._T", en_t), \
              patch("modules.notifier.requests.post") as mock_post:
             mock_post.return_value = self._make_response(204)
             notifier.send_discord_message(sample_games)
 
         _, kwargs = mock_post.call_args
         payload = kwargs["json"]
-        assert payload["embeds"][0]["footer"]["text"].startswith("Finaliza el ")
+        assert payload["embeds"][0]["footer"]["text"].startswith("Ends on ")
 
     def test_embed_author_is_epic_games_store(self, sample_games):
         with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
@@ -161,30 +180,77 @@ class TestSendDiscordMessage:
             description="",
             review_score="Very Positive",
         )
+        en_t = notifier._TRANSLATIONS["en"]
         with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier._T", en_t), \
              patch("modules.notifier.requests.post") as mock_post:
             mock_post.return_value = self._make_response(204)
             notifier.send_discord_message([game])
 
         _, kwargs = mock_post.call_args
         payload = kwargs["json"]
-        fields = payload["embeds"][0].get("fields", [])
-        assert any(
-            f["name"] == "💬 User Reviews:"
-            and "Very Positive" in f["value"]
-            and "⭐" in f["value"]
-            for f in fields
-        )
+        description = payload["embeds"][0]["description"]
+        assert "💬 User Reviews:" in description
+        assert "Very Positive" in description
+        assert "⭐" in description
 
-    def test_embed_no_review_score_field_when_absent(self, sample_games):
+    def test_review_label_is_translated_when_locale_is_spanish(self):
+        game = FreeGame(
+            title="Steam Game",
+            store="steam",
+            url="https://store.steampowered.com/app/123/",
+            image_url="https://example.com/img.jpg",
+            original_price="$9.99",
+            end_date="2024-01-31T15:00:00.000Z",
+            is_permanent=False,
+            description="",
+            review_score="Very Positive",
+        )
+        es_t = notifier._TRANSLATIONS["es"]
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier._T", es_t), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message([game])
+
+        _, kwargs = mock_post.call_args
+        description = kwargs["json"]["embeds"][0]["description"]
+        assert "💬 Opiniones de usuarios:" in description
+        assert "Muy Positivo" in description
+        assert "⭐" in description
+
+    def test_footer_is_translated_when_locale_is_spanish(self, sample_games):
+        es_t = notifier._TRANSLATIONS["es"]
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier._T", es_t), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message(sample_games)
+
+        _, kwargs = mock_post.call_args
+        footer = kwargs["json"]["embeds"][0]["footer"]["text"]
+        assert footer.startswith("Finaliza el ")
+
+    def test_content_message_is_translated_when_locale_is_spanish(self, sample_games):
+        es_t = notifier._TRANSLATIONS["es"]
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier._T", es_t), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message(sample_games)
+
+        _, kwargs = mock_post.call_args
+        assert "¡Nuevo Juego Gratis" in kwargs["json"]["content"]
+
+    def test_embed_no_review_score_when_absent(self, sample_games):
         with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
              patch("modules.notifier.requests.post") as mock_post:
             mock_post.return_value = self._make_response(204)
             notifier.send_discord_message(sample_games)
 
         _, kwargs = mock_post.call_args
-        payload = kwargs["json"]
-        assert "fields" not in payload["embeds"][0]
+        description = kwargs["json"]["embeds"][0]["description"]
+        assert "User Reviews" not in description
 
     def test_content_message_uses_epic_store_name(self, sample_games):
         with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \


### PR DESCRIPTION
## Summary
- Add `_TRANSLATIONS` dict in `notifier.py` with `en` and `es` entries
- `_get_lang()` derives a two-letter code from `LOCALE` (e.g. `es_MX.UTF-8` → `es`); unsupported locales fall back to `en`
- All hardcoded strings in Discord embeds now go through `_T[...]`:
  - Footer prefix ("Ends on" / "Finaliza el")
  - Permanent/unavailable labels
  - Review field name ("💬 User Reviews:" / "💬 Opiniones de usuarios:")
  - Review score labels ("Very Positive" → "Muy Positivo")
  - Content header ("New Free Game!" / "¡Nuevo Juego Gratis!")

## Test plan
- [x] 44/44 tests passing in Docker
- New tests: `TestGetLang` (5 cases), Spanish review label, Spanish footer, Spanish content header
- Existing tests pinned to `_T["en"]` so they're locale-independent

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)