### PR TITLE
fix: prevent duplicate Steam notifications when scraper temporarily returns empty

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,30 +63,51 @@ console_handler.setFormatter(TimezoneFormatter('%(asctime)s - %(name)s - %(level
 logging.basicConfig(level=logging.INFO, handlers=[log_handler, console_handler])
 
 
+def _is_still_active(game) -> bool:
+    """Return True if *game*'s promotion has not yet expired.
+
+    Games with an empty or un-parseable end_date are treated as still-active to
+    avoid false "new game" alerts caused by transient scraping failures.
+    """
+    end_date = game.end_date
+    if not end_date:
+        # Treat unknown end dates as active to avoid duplicate notifications.
+        return True
+
+    normalized = end_date.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+
+    try:
+        ends_at = datetime.fromisoformat(normalized)
+    except ValueError:
+        # Keep legacy/malformed records from causing false "new" alerts.
+        return True
+
+    if ends_at.tzinfo is None:
+        ends_at = ends_at.replace(tzinfo=timezone.utc)
+
+    return ends_at >= datetime.now(timezone.utc)
+
+
 def _find_new_games(current_games, previous_games):
-    """Return games that are newly free compared to still-active previous promos."""
+    """Return games that are newly free compared to still-active previous promos.
 
-    def _is_still_active(previous_game):
-        end_date = previous_game.end_date
-        if not end_date:
-            # Treat unknown end dates as active to avoid duplicate notifications.
-            return True
+    Two checks prevent duplicate notifications:
 
-        normalized = end_date.strip()
-        if normalized.endswith("Z"):
-            normalized = normalized[:-1] + "+00:00"
+    1. ``previous_active_urls`` — URLs whose promos are still running.  A game
+       whose URL is already active is suppressed regardless of its end_date.
+    2. ``previous_seen`` — (url, end_date) pairs ever persisted.  Prevents
+       re-notification for an expired promo even if the URL no longer appears
+       in the active set.
 
-        try:
-            ends_at = datetime.fromisoformat(normalized)
-        except ValueError:
-            # Keep legacy/malformed records from causing false "new" alerts.
-            return True
+    A game that passes *both* checks is genuinely new or has started a fresh
+    promo with a different end_date.
 
-        if ends_at.tzinfo is None:
-            ends_at = ends_at.replace(tzinfo=timezone.utc)
-
-        return ends_at >= datetime.now(timezone.utc)
-
+    Same-run deduplication: ``notified_urls`` tracks URLs already added to
+    ``new_games`` in this loop so that a URL appearing twice in ``current_games``
+    (e.g. duplicate search-result rows) is only notified once.
+    """
     # A (url, end_date) pair that already appeared in previous games should not
     # trigger a new notification, regardless of whether the promo is still active.
     # This prevents re-notifying for the same expired promo while still allowing
@@ -105,11 +126,17 @@ def _find_new_games(current_games, previous_games):
     }
 
     new_games = []
+    notified_urls: set[str] = set()
     for game in current_games:
         url = game.url
         if url:
-            if url not in previous_active_urls and (url, game.end_date) not in previous_seen:
+            if (
+                url not in previous_active_urls
+                and (url, game.end_date) not in previous_seen
+                and url not in notified_urls
+            ):
                 new_games.append(game)
+                notified_urls.add(url)
             continue
 
         # Fallback for malformed records that do not have a url.
@@ -188,10 +215,31 @@ def check_games():
     else:
         logging.warning("No new free games detected.")
 
-    # Always persist current_games so that the DB upsert keeps end_date values
-    # fresh, preventing stale promos from triggering false re-notifications.
+    # Always persist so that the DB upsert keeps end_date values fresh, preventing
+    # stale promos from triggering false re-notifications.
+    #
+    # Guard against scraper failures causing re-notifications: if an enabled store
+    # returned no games this run (network error, rate-limit, or a genuinely empty
+    # day), its previously-stored still-active games would be erased from storage.
+    # The next run that does return those games would then treat them as new and
+    # send a duplicate Discord notification.  To prevent this, we carry forward
+    # still-active previous games from any store that produced no results.
+    stores_with_results = {g.store for g in current_games}
+    preserved = [
+        g for g in previous_games
+        if g.store not in stores_with_results and _is_still_active(g)
+    ]
+    if preserved:
+        logging.info(
+            "Carrying forward %d still-active game(s) from store(s) with no results "
+            "this run to prevent duplicate notifications: %s",
+            len(preserved),
+            [g.title for g in preserved],
+        )
+    games_to_save = current_games + preserved
+
     try:
-        save_games(current_games)
+        save_games(games_to_save)
         logging.info("Games saved successfully to storage")
     except IOError as e:
         logging.error(f"Failed to save games to storage: {str(e)}")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -13,7 +13,13 @@ def _import_main():
     main.py creates a TimedRotatingFileHandler at module level which requires
     /mnt/logs/notifier.log to exist.  In the test environment this path is not
     available, so we mock the handler class before the module is loaded.
+
+    alembic may also be absent in the local dev environment; setdefault inserts
+    a stub only when the real package is not installed (no-op in CI).
     """
+    sys.modules.setdefault("alembic", MagicMock())
+    sys.modules.setdefault("alembic.config", MagicMock())
+    sys.modules.setdefault("alembic.command", MagicMock())
     # Remove cached module so it is re-executed under the mock.
     sys.modules.pop("main", None)
     with patch("logging.handlers.TimedRotatingFileHandler"):
@@ -38,6 +44,8 @@ class TestRunDbMigrations:
 
     def test_passes_alembic_config_object(self):
         """_run_db_migrations should pass an AlembicConfig instance to upgrade."""
+        if isinstance(sys.modules.get("alembic"), MagicMock):
+            pytest.skip("alembic not installed; skipping AlembicConfig isinstance check")
         from alembic.config import Config as AlembicConfig
         main = _import_main()
 

--- a/tests/test_multi_store_pipeline.py
+++ b/tests/test_multi_store_pipeline.py
@@ -13,6 +13,13 @@ from modules.models import FreeGame
 
 
 def _import_main():
+    # Stub out heavy optional deps that may be absent in the local dev environment.
+    # setdefault is a no-op when the real package is already installed (e.g. in CI),
+    # so this does not affect the production import path.
+    sys.modules.setdefault("alembic", MagicMock())
+    sys.modules.setdefault("alembic.config", MagicMock())
+    sys.modules.setdefault("alembic.command", MagicMock())
+
     sys.modules.pop("main", None)
     with patch("logging.handlers.TimedRotatingFileHandler"):
         import main as _main
@@ -172,3 +179,84 @@ class TestMultiStorePipeline:
         saved = mock_save.call_args[0][0]
         assert len(saved) == 2
         assert {g.store for g in saved} == {"epic", "steam"}
+
+    def test_active_steam_game_preserved_in_storage_when_steam_scraper_returns_empty(self):
+        """If Steam scraper returns [] but a still-active Steam game was in previous storage,
+        that game must be carried forward in save_games to prevent a duplicate notification
+        on the next successful Steam scrape."""
+        main = _import_main()
+
+        epic_game = _epic_game("Epic Game", "https://store.epicgames.com/p/epic-game")
+        # A Steam game that was previously stored and whose promo is still active.
+        active_steam = _steam_game(
+            "Active Steam Game",
+            "https://store.steampowered.com/app/6/active-steam",
+            end_date="2099-01-01T00:00:00.000Z",
+        )
+
+        with patch("main.ENABLED_STORES", ["epic", "steam"]), \
+             patch("modules.scrapers.epic.EpicGamesScraper.fetch_free_games", return_value=[epic_game]), \
+             patch("modules.scrapers.steam.SteamScraper.fetch_free_games", return_value=[]), \
+             patch("main.load_previous_games", return_value=[epic_game, active_steam]), \
+             patch("main.send_discord_message"), \
+             patch("main.save_last_notification"), \
+             patch("main.save_games") as mock_save:
+            main.check_games()
+
+        mock_save.assert_called_once()
+        saved = mock_save.call_args[0][0]
+        saved_urls = {g.url for g in saved}
+        assert active_steam.url in saved_urls, (
+            "Still-active Steam game must be preserved in storage when Steam scraper "
+            "returns no results, to prevent a duplicate notification next run."
+        )
+
+    def test_expired_steam_game_not_preserved_when_steam_scraper_returns_empty(self):
+        """An expired Steam game should NOT be carried forward even if Steam scraper
+        returns empty — its promo is over so there is no re-notification risk."""
+        main = _import_main()
+
+        epic_game = _epic_game("Epic Game", "https://store.epicgames.com/p/epic-game")
+        expired_steam = _steam_game(
+            "Expired Steam Game",
+            "https://store.steampowered.com/app/7/expired-steam",
+            end_date="2000-01-01T00:00:00.000Z",  # long expired
+        )
+
+        with patch("main.ENABLED_STORES", ["epic", "steam"]), \
+             patch("modules.scrapers.epic.EpicGamesScraper.fetch_free_games", return_value=[epic_game]), \
+             patch("modules.scrapers.steam.SteamScraper.fetch_free_games", return_value=[]), \
+             patch("main.load_previous_games", return_value=[epic_game, expired_steam]), \
+             patch("main.send_discord_message"), \
+             patch("main.save_last_notification"), \
+             patch("main.save_games") as mock_save:
+            main.check_games()
+
+        mock_save.assert_called_once()
+        saved = mock_save.call_args[0][0]
+        saved_urls = {g.url for g in saved}
+        assert expired_steam.url not in saved_urls, (
+            "Expired Steam game must not be carried forward — its promo is over."
+        )
+
+    def test_duplicate_url_in_current_games_notified_only_once(self):
+        """If the same URL appears twice in current_games (e.g. duplicate search rows),
+        only one Discord embed should be generated for it."""
+        main = _import_main()
+
+        game_a = _steam_game("Dup Game", "https://store.steampowered.com/app/8/dup-game")
+        game_b = _steam_game("Dup Game", "https://store.steampowered.com/app/8/dup-game")
+
+        with patch("main.ENABLED_STORES", ["steam"]), \
+             patch("modules.scrapers.steam.SteamScraper.fetch_free_games", return_value=[game_a, game_b]), \
+             patch("main.load_previous_games", return_value=[]), \
+             patch("main.send_discord_message") as mock_send, \
+             patch("main.save_last_notification"), \
+             patch("main.save_games"):
+            main.check_games()
+
+        mock_send.assert_called_once()
+        notified = mock_send.call_args[0][0]
+        assert len(notified) == 1, (
+            "Same URL appearing twice in current_games must only produce one notification embed."
+        )


### PR DESCRIPTION
## Summary

Fixes two bugs that caused Steam games to be notified more than once.

### Bug 1 — Scraper failure "forgets" stored games (primary cause)

`save_games(current_games)` was called with only the games scraped in the current run. If the Steam scraper temporarily returned `[]` due to a rate-limit (HTTP 429), network error, or a legitimately empty day, any still-active Steam games stored from a previous run were silently erased from storage. The next successful scrape would see those same games as brand new and send another Discord notification.

**Fix:** Before saving, still-active games from any enabled store that produced no results are carried forward into `games_to_save`. A log line is emitted so this is visible in the logs.

### Bug 2 — Same URL notified twice in one run (secondary)

`_find_new_games` compared each entry in `current_games` against `previous_games` only. If the same URL appeared twice in the current scrape (e.g. duplicate rows from the Steam search page), both copies would pass the deduplication check and produce two embeds in a single Discord message.

**Fix:** Added `notified_urls` set inside `_find_new_games` to deduplicate within the current run.

### Other changes

- `_is_still_active` extracted to module level (reused by both fixes, previously nested inside `_find_new_games`).
- `_import_main` helpers in `test_multi_store_pipeline.py` and `test_migrations.py` updated with `setdefault` alembic stubs so the tests run locally without alembic installed (no-op in CI where alembic is present).

## Test plan

- [x] New test: `test_active_steam_game_preserved_in_storage_when_steam_scraper_returns_empty` — verifies bug 1 fix
- [x] New test: `test_expired_steam_game_not_preserved_when_steam_scraper_returns_empty` — verifies expired games are NOT preserved (correct cleanup)
- [x] New test: `test_duplicate_url_in_current_games_notified_only_once` — verifies bug 2 fix
- [x] All 9 multi-store pipeline tests pass
- [x] Full local test suite: 227 passed, 1 skipped (alembic isinstance check, only meaningful in CI)

Closes no issue — production hotfix targeting QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)