### PR TITLE
fix: remove unused PR trigger types from sync-project-status workflow

### DIFF
--- a/.github/workflows/sync-project-status.yml
+++ b/.github/workflows/sync-project-status.yml
@@ -2,7 +2,7 @@ name: Sync Issue Status with Project Board
 
 on:
   pull_request:
-    types: [opened, edited, ready_for_review, reopened, closed]
+    types: [opened, ready_for_review, closed]
   issues:
     types: [labeled]
 


### PR DESCRIPTION
## Summary

- Removes `edited` and `reopened` from the `pull_request` trigger types in `sync-project-status.yml`
- Neither event had a matching job step, so the workflow was firing and immediately doing nothing — generating "No jobs were run" email spam on every PR edit

## Test plan

- [ ] Verify no new "No jobs were run" emails after editing a PR description
- [ ] Verify the workflow still triggers correctly on `opened`, `ready_for_review`, and `closed` PR events

🤖 Generated with [Claude Code](https://claude.com/claude-code)