### PR TITLE
Remove unused PR trigger types from workflow

### DIFF
--- a/.github/workflows/sync-project-status.yml
+++ b/.github/workflows/sync-project-status.yml
@@ -2,7 +2,7 @@ name: Sync Issue Status with Project Board
 
 on:
   pull_request:
-    types: [opened, edited, ready_for_review, reopened, closed]
+    types: [opened, ready_for_review, closed]
   issues:
     types: [labeled]
 


### PR DESCRIPTION
This pull request makes a minor update to the workflow trigger configuration in `.github/workflows/sync-project-status.yml`. The change removes the `edited` and `reopened` event types from the list of pull request events that trigger the workflow.