### PR TITLE
feat: display original price in Discord notifications (#107)

### DIFF
--- a/modules/notifier.py
+++ b/modules/notifier.py
@@ -20,6 +20,7 @@ _TRANSLATIONS = {
         "permanently_free": "Permanently free",
         "end_date_unavailable": "End date unavailable",
         "user_reviews": "💬 User Reviews:",
+        "original_price": "💰 Original Price",
         "new_free_game": "**New Free Game on {store}! 🎮**\n",
         "new_free_games": "**New Free Games! 🎮**\n",
         "review_labels": {
@@ -40,6 +41,7 @@ _TRANSLATIONS = {
         "permanently_free": "Gratis de forma permanente",
         "end_date_unavailable": "Fecha de fin no disponible",
         "user_reviews": "💬 Opiniones de usuarios:",
+        "original_price": "💰 Precio original",
         "new_free_game": "**¡Nuevo Juego Gratis en {store}! 🎮**\n",
         "new_free_games": "**¡Nuevos Juegos Gratis! 🎮**\n",
         "review_labels": {
@@ -271,6 +273,12 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
                     emoji = _REVIEW_EMOJIS.get(key, "🎮")
                     label = _T["review_labels"].get(key, game.review_score)
                     embed["description"] += f"\n\n{_T['user_reviews']}\n{label} {emoji}\n\n"
+                if game.original_price:
+                    embed.setdefault("fields", []).append({
+                        "name": _T["original_price"],
+                        "value": game.original_price,
+                        "inline": True,
+                    })
                 embeds.append(embed)
             except (AttributeError, ValueError) as e:
                 logger.error(f"Error processing game data for embed: {str(e)} | Game data: {game}")

--- a/modules/scrapers/epic.py
+++ b/modules/scrapers/epic.py
@@ -55,6 +55,14 @@ class EpicGamesScraper(BaseScraper):
         for game in data["data"]["Catalog"]["searchStore"]["elements"]:
             price_info = game.get("price", {}).get("totalPrice", {})
             if price_info.get("discountPrice", 1) == 0:
+                original_price_int = price_info.get("originalPrice", 0)
+                if original_price_int > 0:
+                    fmt = price_info.get("fmtPrice", {})
+                    original_price = fmt.get("originalPrice") or None
+                    if original_price == "0":
+                        original_price = None
+                else:
+                    original_price = None
                 ## Get the game title
                 title = game["title"]
                 logger.info(f"Found free game!: {title}")
@@ -140,7 +148,7 @@ class EpicGamesScraper(BaseScraper):
                         store=self.store_name,
                         url=link,
                         image_url=thumbnail,
-                        original_price=None,
+                        original_price=original_price,
                         end_date=end_date,
                         is_permanent=False,
                         description=description,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,10 @@ def epic_api_response():
                                 "totalPrice": {
                                     "discountPrice": 0,
                                     "originalPrice": 1999,
+                                    "fmtPrice": {
+                                        "originalPrice": "$19.99",
+                                        "discountPrice": "$0.00",
+                                    },
                                 }
                             },
                             "offerMappings": [{"pageSlug": "test-free-game"}],

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -242,6 +242,60 @@ class TestSendDiscordMessage:
         _, kwargs = mock_post.call_args
         assert "¡Nuevo Juego Gratis" in kwargs["json"]["content"]
 
+    def test_embed_includes_original_price_field_when_present(self):
+        game = FreeGame(
+            title="Epic Game",
+            store="epic",
+            url="https://store.epicgames.com/p/epic-game",
+            image_url="https://example.com/img.jpg",
+            original_price="$19.99",
+            end_date="2024-01-31T15:00:00.000Z",
+            is_permanent=False,
+            description="",
+        )
+        en_t = notifier._TRANSLATIONS["en"]
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier._T", en_t), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message([game])
+
+        _, kwargs = mock_post.call_args
+        fields = kwargs["json"]["embeds"][0].get("fields", [])
+        assert any(f["name"] == "💰 Original Price" and f["value"] == "$19.99" for f in fields)
+
+    def test_embed_original_price_field_translated_to_spanish(self):
+        game = FreeGame(
+            title="Epic Game",
+            store="epic",
+            url="https://store.epicgames.com/p/epic-game",
+            image_url="https://example.com/img.jpg",
+            original_price="$19.99",
+            end_date="2024-01-31T15:00:00.000Z",
+            is_permanent=False,
+            description="",
+        )
+        es_t = notifier._TRANSLATIONS["es"]
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier._T", es_t), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message([game])
+
+        _, kwargs = mock_post.call_args
+        fields = kwargs["json"]["embeds"][0].get("fields", [])
+        assert any(f["name"] == "💰 Precio original" and f["value"] == "$19.99" for f in fields)
+
+    def test_embed_no_original_price_field_when_absent(self, sample_games):
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message(sample_games)
+
+        _, kwargs = mock_post.call_args
+        fields = kwargs["json"]["embeds"][0].get("fields", [])
+        assert not any("Original Price" in f.get("name", "") for f in fields)
+
     def test_embed_no_review_score_when_absent(self, sample_games):
         with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
              patch("modules.notifier.requests.post") as mock_post:

--- a/tests/test_scrapper.py
+++ b/tests/test_scrapper.py
@@ -28,6 +28,10 @@ def _make_element(
             "totalPrice": {
                 "discountPrice": discount_price,
                 "originalPrice": 1999,
+                "fmtPrice": {
+                    "originalPrice": "$19.99",
+                    "discountPrice": "$0.00",
+                },
             }
         },
         "offerMappings": [{"pageSlug": offer_slug}] if offer_slug else [],
@@ -93,6 +97,7 @@ class TestFetchFreeGames:
         assert games[0].end_date == "2024-01-31T15:00:00.000Z"
         assert games[0].description == "A free game for testing"
         assert games[0].image_url == "https://example.com/thumbnail.jpg"
+        assert games[0].original_price == "$19.99"
 
     def test_excludes_paid_games(self):
         paid = _make_element(discount_price=1999)
@@ -200,6 +205,33 @@ class TestFetchFreeGames:
             games = scraper.fetch_free_games()
 
         assert games == []
+
+    def test_original_price_populated_from_fmt_price(self):
+        element = _make_element(discount_price=0, offer_slug="game-one")
+        with patch("modules.scrapers.epic.requests.get") as mock_get:
+            mock_get.return_value = _mock_response(200, _make_api_response([element]))
+            games = EpicGamesScraper().fetch_free_games()
+
+        assert games[0].original_price == "$19.99"
+
+    def test_original_price_is_none_when_int_price_is_zero(self):
+        element = _make_element(discount_price=0, offer_slug="always-free")
+        element["price"]["totalPrice"]["originalPrice"] = 0
+        element["price"]["totalPrice"]["fmtPrice"]["originalPrice"] = "0"
+        with patch("modules.scrapers.epic.requests.get") as mock_get:
+            mock_get.return_value = _mock_response(200, _make_api_response([element]))
+            games = EpicGamesScraper().fetch_free_games()
+
+        assert games[0].original_price is None
+
+    def test_original_price_is_none_when_fmt_price_missing(self):
+        element = _make_element(discount_price=0, offer_slug="game-one")
+        del element["price"]["totalPrice"]["fmtPrice"]
+        with patch("modules.scrapers.epic.requests.get") as mock_get:
+            mock_get.return_value = _mock_response(200, _make_api_response([element]))
+            games = EpicGamesScraper().fetch_free_games()
+
+        assert games[0].original_price is None
 
     def test_multiple_free_games_returned(self):
         elements = [


### PR DESCRIPTION
## Summary
- Populate `original_price` for Epic Games Store games from `price.totalPrice.fmtPrice.originalPrice` in the API response (previously always `None`)
- Add a **💰 Original Price** field to Discord embeds when `original_price` is available; omitted gracefully when absent or when a game has no original price (always-free)
- Add `"original_price"` translation key in English (`💰 Original Price`) and Spanish (`💰 Precio original`)

## Test plan
- [x] `test_original_price_populated_from_fmt_price` — Epic scraper reads the formatted price string
- [x] `test_original_price_is_none_when_int_price_is_zero` — always-free games produce `None`
- [x] `test_original_price_is_none_when_fmt_price_missing` — graceful fallback when field is absent
- [x] `test_embed_includes_original_price_field_when_present` — field appears in embed
- [x] `test_embed_original_price_field_translated_to_spanish` — Spanish label rendered correctly
- [x] `test_embed_no_original_price_field_when_absent` — field absent when `original_price` is `None`
- [x] All 62 existing tests continue to pass

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)