### PR TITLE
fix: suppress re-notification for recently-expired games with bad end_date

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from modules.notifier import send_discord_message
 from modules.scrapers import get_enabled_scrapers
@@ -101,19 +101,54 @@ def _is_still_active(game) -> bool:
     return ends_at >= datetime.now(timezone.utc)
 
 
+_RECENTLY_EXPIRED_GRACE_PERIOD_HOURS = 24
+
+
+def _recently_expired_urls(previous_games) -> set[str]:
+    """Return URLs whose promo expired within the last grace period.
+
+    Steam (and other stores) occasionally return a wrong end_date for a game
+    whose promo just ended (e.g. off-by-one year).  Without this guard,
+    a URL that expired minutes ago would pass both the ``previous_active_urls``
+    and ``previous_seen`` checks and trigger a duplicate notification.
+    """
+    now = datetime.now(timezone.utc)
+    grace = timedelta(hours=_RECENTLY_EXPIRED_GRACE_PERIOD_HOURS)
+    urls: set[str] = set()
+    for game in previous_games:
+        if not game.url or not game.end_date:
+            continue
+        normalized = game.end_date.strip()
+        if normalized.endswith("Z"):
+            normalized = normalized[:-1] + "+00:00"
+        try:
+            ends_at = datetime.fromisoformat(normalized)
+        except ValueError:
+            continue
+        if ends_at.tzinfo is None:
+            ends_at = ends_at.replace(tzinfo=timezone.utc)
+        if ends_at < now <= ends_at + grace:
+            urls.add(game.url)
+    return urls
+
+
 def _find_new_games(current_games, previous_games):
     """Return games that are newly free compared to still-active previous promos.
 
-    Two checks prevent duplicate notifications:
+    Three checks prevent duplicate notifications:
 
     1. ``previous_active_urls`` — URLs whose promos are still running.  A game
        whose URL is already active is suppressed regardless of its end_date.
-    2. ``previous_seen`` — (url, end_date) pairs ever persisted.  Prevents
+    2. ``recently_expired_urls`` — URLs whose promo ended within the last
+       ``_RECENTLY_EXPIRED_GRACE_PERIOD_HOURS`` hours.  This prevents a store
+       returning a bad end_date (e.g. wrong year) right after expiry from
+       triggering a re-notification for the same promotion.
+    3. ``previous_seen`` — (url, end_date) pairs ever persisted.  Prevents
        re-notification for an expired promo even if the URL no longer appears
        in the active set.
 
-    A game that passes *both* checks is genuinely new or has started a fresh
-    promo with a different end_date.
+    A game that passes *all* checks is genuinely new or has started a fresh
+    promo with a different end_date after the grace period.
 
     Same-run deduplication: ``notified_urls`` tracks URLs already added to
     ``new_games`` in this loop so that a URL appearing twice in ``current_games``
@@ -136,6 +171,11 @@ def _find_new_games(current_games, previous_games):
         if game.url and _is_still_active(game)
     }
 
+    # Suppress re-notification for URLs whose promo just expired — store data
+    # errors (e.g. Steam returning a wrong year) would otherwise bypass both
+    # previous_active_urls and previous_seen when the end_date differs.
+    recently_expired = _recently_expired_urls(previous_games)
+
     new_games = []
     notified_urls: set[str] = set()
     for game in current_games:
@@ -143,6 +183,7 @@ def _find_new_games(current_games, previous_games):
         if url:
             if (
                 url not in previous_active_urls
+                and url not in recently_expired
                 and (url, game.end_date) not in previous_seen
                 and url not in notified_urls
             ):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -494,3 +494,83 @@ class TestFindNewGamesEdgeCases:
         result = main._find_new_games(current_games, previous_games)
 
         assert result == current_games, "Naive past end_date should be treated as expired; game should appear as new"
+
+    def test_recently_expired_with_different_end_date_not_renotified(self):
+        """A game whose promo expired within the grace period must not trigger a
+        re-notification even when the store returns a different end_date.
+
+        Reproduces the SurrounDead bug: Steam returned end_date with the wrong
+        year (2027 instead of 2026) minutes after the original promo ended,
+        causing _find_new_games to treat it as a brand-new game.
+        """
+        from datetime import datetime, timedelta, timezone
+        main = _import_main()
+
+        # Simulate an end_date that expired 30 minutes ago.
+        expired_recently = (
+            datetime.now(timezone.utc) - timedelta(minutes=30)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # The store now returns the same URL but with a wrong end_date (a year later).
+        wrong_end_date = (
+            datetime.now(timezone.utc) + timedelta(days=365)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        previous_games = [
+            _make_game(
+                "SurrounDead Poly Construction",
+                "https://store.steampowered.com/app/4148570/SurrounDead_Poly_Construction/",
+                end_date=expired_recently,
+            )
+        ]
+        current_games = [
+            _make_game(
+                "SurrounDead Poly Construction",
+                "https://store.steampowered.com/app/4148570/SurrounDead_Poly_Construction/",
+                end_date=wrong_end_date,
+            )
+        ]
+
+        result = main._find_new_games(current_games, previous_games)
+
+        assert result == [], (
+            "A recently-expired game returning a different end_date should not "
+            "trigger a re-notification within the grace period"
+        )
+
+    def test_long_expired_game_with_new_end_date_is_renotified(self):
+        """A game whose promo expired well beyond the grace period IS allowed to
+        re-notify if the store shows it free again with a new end_date.
+        """
+        from datetime import datetime, timedelta, timezone
+        main = _import_main()
+
+        old_end_date = (
+            datetime.now(timezone.utc) - timedelta(days=30)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        new_end_date = (
+            datetime.now(timezone.utc) + timedelta(days=7)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        previous_games = [
+            _make_game(
+                "Recurring Game",
+                "https://store.steampowered.com/app/99999/Recurring_Game/",
+                end_date=old_end_date,
+            )
+        ]
+        current_games = [
+            _make_game(
+                "Recurring Game",
+                "https://store.steampowered.com/app/99999/Recurring_Game/",
+                end_date=new_end_date,
+            )
+        ]
+
+        result = main._find_new_games(current_games, previous_games)
+
+        assert result == current_games, (
+            "A game that was free long ago and is now free again should trigger "
+            "a new notification"
+        )


### PR DESCRIPTION
## Summary

- **Root cause:** Steam returned `end_date='2027-04-25T16:00:00Z'` for SurrounDead Poly Construction minutes after its real promo ended at `2026-04-25T16:00:00Z`. Because Mexico City no longer observes DST (UTC-6), the 10:58 AM local check ran at 16:58 UTC — after the 16:00 UTC expiry — so `_is_still_active` returned `False`. The different year also bypassed the `(url, end_date)` check in `previous_seen`, and a duplicate notification was sent.
- Added `_recently_expired_urls()`: builds a set of URLs whose promo ended within the last 24 hours. `_find_new_games` now checks this set as a third guard, blocking false re-notifications caused by bad store data without affecting legitimate re-promotions (games that become free again after a long gap).
- Added two regression tests covering both the suppressed case and the allowed re-notification case.

## Test plan

- [x] `test_recently_expired_with_different_end_date_not_renotified` — confirms the SurrounDead scenario no longer triggers a notification
- [x] `test_long_expired_game_with_new_end_date_is_renotified` — confirms a game free again after 30+ days still sends a notification
- [x] All 226 existing tests pass (`pytest tests/ --ignore=tests/test_api_integration.py --ignore=tests/test_migrations.py` + `pytest tests/test_migrations.py`)

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)