### PR TITLE
feat: show original price in Discord embeds and add STEAM_COUNTRY config (#107)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,12 @@ ENABLE_HEALTHCHECK=false
 # Examples: es-MX, de-DE, fr-FR, pt-BR
 # EPIC_GAMES_REGION=en-US
 
+# Optional: Country code for Steam store requests (controls currency in prices).
+# Uses ISO 3166-1 alpha-2 codes. Defaults to "US" (prices in USD).
+# Set this to match your region so Steam returns prices in your local currency.
+# Examples: MX (MXN), DE (EUR), GB (GBP), BR (BRL)
+# STEAM_COUNTRY=US
+
 # Optional: How often to check for new free games, in hours.
 # When set, the service runs on a repeating interval instead of once per day.
 # Recommended for multi-store setups (Steam games can appear at any time).

--- a/config.py
+++ b/config.py
@@ -24,6 +24,11 @@ STEAM_SEARCH_URL = os.getenv("STEAM_SEARCH_URL", "https://store.steampowered.com
 # Full list: https://partner.steamgames.com/doc/store/localization/languages
 STEAM_LANGUAGE = os.getenv("STEAM_LANGUAGE", "english")
 
+# Country code passed to the Steam store API to get region-correct prices.
+# Uses ISO 3166-1 alpha-2 codes (e.g. "US", "MX", "DE", "GB").
+# Defaults to "US". Set to match your region to get prices in your local currency.
+STEAM_COUNTRY = os.getenv("STEAM_COUNTRY", "US")
+
 # Minimum delay in milliseconds between Steam HTTP requests to avoid rate limiting
 _raw_steam_delay = os.getenv("STEAM_REQUEST_DELAY_MS")
 try:

--- a/modules/notifier.py
+++ b/modules/notifier.py
@@ -19,6 +19,7 @@ _TRANSLATIONS = {
         "ends_on": "Ends on",
         "permanently_free": "Permanently free",
         "end_date_unavailable": "End date unavailable",
+        "original_price": "Original Price",
         "user_reviews": "💬 User Reviews:",
         "new_free_game": "**New Free Game on {store}! 🎮**\n",
         "new_free_games": "**New Free Games! 🎮**\n",
@@ -39,6 +40,7 @@ _TRANSLATIONS = {
         "ends_on": "Finaliza el",
         "permanently_free": "Gratis de forma permanente",
         "end_date_unavailable": "Fecha de fin no disponible",
+        "original_price": "Precio original",
         "user_reviews": "💬 Opiniones de usuarios:",
         "new_free_game": "**¡Nuevo Juego Gratis en {store}! 🎮**\n",
         "new_free_games": "**¡Nuevos Juegos Gratis! 🎮**\n",
@@ -238,6 +240,14 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
                 else:
                     footer_text = _T["end_date_unavailable"]
 
+                fields = []
+                if game.original_price:
+                    fields.append({
+                        "name": _T["original_price"],
+                        "value": game.original_price,
+                        "inline": True,
+                    })
+
                 embed = {
                     "author": {
                         "name": store_meta["name"],
@@ -255,6 +265,8 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
                         "text": footer_text
                     },
                 }
+                if fields:
+                    embed["fields"] = fields
                 if game.review_score:
                     _REVIEW_EMOJIS = {
                         "overwhelmingly positive": "🏆",

--- a/modules/scrapers/steam.py
+++ b/modules/scrapers/steam.py
@@ -9,7 +9,7 @@ from typing import Optional
 import requests
 from bs4 import BeautifulSoup
 
-from config import STEAM_LANGUAGE, STEAM_REQUEST_DELAY_MS, STEAM_SEARCH_URL, TIMEZONE
+from config import STEAM_COUNTRY, STEAM_LANGUAGE, STEAM_REQUEST_DELAY_MS, STEAM_SEARCH_URL, TIMEZONE
 from modules.models import FreeGame
 from modules.retry import with_retry
 from modules.scrapers.base import BaseScraper
@@ -51,7 +51,6 @@ _AGE_CHECK_COOKIES = {
 _SEARCH_PARAMS = {
     "maxprice": "free",
     "specials": 1,
-    "cc": "US",
     "l": "english",
 }
 
@@ -136,7 +135,7 @@ class SteamScraper(BaseScraper):
             response = with_retry(
                 func=lambda: _steam_get(
                     STEAM_SEARCH_URL,
-                    params=_SEARCH_PARAMS,
+                    params={**_SEARCH_PARAMS, "cc": STEAM_COUNTRY},
                     headers=_HEADERS,
                     timeout=10,
                 ),
@@ -226,7 +225,7 @@ class SteamScraper(BaseScraper):
             response = with_retry(
                 func=lambda: _steam_get(
                     _APPDETAILS_URL,
-                    params={"appids": appid, "cc": "US", "l": STEAM_LANGUAGE},
+                    params={"appids": appid, "cc": STEAM_COUNTRY, "l": STEAM_LANGUAGE},
                     headers=_HEADERS,
                     timeout=10,
                 ),

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -447,6 +447,73 @@ class TestSendDiscordMessage:
         assert footer == "Gratis de forma permanente"
 
 
+    def test_embed_shows_original_price_when_present(self):
+        """When original_price is set, the embed includes a field with its value."""
+        game = FreeGame(
+            title="Priced Game",
+            store="steam",
+            url="https://store.steampowered.com/app/123/",
+            image_url="https://example.com/img.jpg",
+            original_price="$19.99",
+            end_date="2024-01-31T15:00:00.000Z",
+            is_permanent=False,
+            description="A great game.",
+        )
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message([game])
+
+        _, kwargs = mock_post.call_args
+        fields = kwargs["json"]["embeds"][0].get("fields", [])
+        assert any(f["value"] == "$19.99" for f in fields)
+        assert any("Price" in f["name"] or "Precio" in f["name"] for f in fields)
+
+    def test_embed_omits_original_price_when_none(self):
+        """When original_price is None, no price field appears in the embed."""
+        game = FreeGame(
+            title="Free Forever",
+            store="epic",
+            url="https://store.epicgames.com/p/free",
+            image_url="https://example.com/img.jpg",
+            original_price=None,
+            end_date="",
+            is_permanent=True,
+            description="",
+        )
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message([game])
+
+        _, kwargs = mock_post.call_args
+        fields = kwargs["json"]["embeds"][0].get("fields", [])
+        assert not any("price" in f["name"].lower() or "precio" in f["name"].lower() for f in fields)
+
+    def test_embed_shows_original_price_label_in_spanish(self):
+        """When the locale is Spanish, the price field uses the Spanish label."""
+        game = FreeGame(
+            title="Juego con precio",
+            store="epic",
+            url="https://store.epicgames.com/p/juego",
+            image_url="https://example.com/img.jpg",
+            original_price="$14.99",
+            end_date="2024-01-31T15:00:00.000Z",
+            is_permanent=False,
+            description="",
+        )
+        es_t = notifier._TRANSLATIONS["es"]
+        with patch("modules.notifier.DISCORD_WEBHOOK_URL", VALID_WEBHOOK), \
+             patch("modules.notifier._T", es_t), \
+             patch("modules.notifier.requests.post") as mock_post:
+            mock_post.return_value = self._make_response(204)
+            notifier.send_discord_message([game])
+
+        _, kwargs = mock_post.call_args
+        fields = kwargs["json"]["embeds"][0].get("fields", [])
+        assert any(f["name"] == "Precio original" for f in fields)
+
+
 class TestSendDiscordMessageWebhookOverride:
     """Tests for the optional webhook_url override in send_discord_message."""
 

--- a/tests/test_steam_scrapper.py
+++ b/tests/test_steam_scrapper.py
@@ -398,6 +398,66 @@ class TestSteamScraper:
 
         assert captured.get("params", {}).get("l") == "english"
 
+    def test_search_uses_configured_country(self):
+        """fetch_free_games passes STEAM_COUNTRY as the cc= param in the search request."""
+        captured = {}
+
+        def side_effect(url, **kwargs):
+            if "search" in url:
+                captured["params"] = kwargs.get("params", {})
+                return _mock_response(200, text=_make_search_html())
+            if "appdetails" in url:
+                return _mock_response(200, json_data=_make_appdetails_response("978520"))
+            if "appreviews" in url:
+                return _mock_response(200, json_data=_make_appreviews_response())
+            return _mock_response(200, text="<html></html>")
+
+        with patch("modules.scrapers.steam.requests.get", side_effect=side_effect), \
+             patch("modules.scrapers.steam.STEAM_COUNTRY", "MX"):
+            SteamScraper().fetch_free_games()
+
+        assert captured.get("params", {}).get("cc") == "MX"
+
+    def test_search_defaults_to_us_country(self):
+        """Without a STEAM_COUNTRY override, the search uses cc=US."""
+        captured = {}
+
+        def side_effect(url, **kwargs):
+            if "search" in url:
+                captured["params"] = kwargs.get("params", {})
+                return _mock_response(200, text=_make_search_html())
+            if "appdetails" in url:
+                return _mock_response(200, json_data=_make_appdetails_response("978520"))
+            if "appreviews" in url:
+                return _mock_response(200, json_data=_make_appreviews_response())
+            return _mock_response(200, text="<html></html>")
+
+        with patch("modules.scrapers.steam.requests.get", side_effect=side_effect), \
+             patch("modules.scrapers.steam.STEAM_COUNTRY", "US"):
+            SteamScraper().fetch_free_games()
+
+        assert captured.get("params", {}).get("cc") == "US"
+
+    def test_appdetails_uses_configured_country(self):
+        """_fetch_appdetails passes STEAM_COUNTRY as the cc= param to the appdetails API."""
+        captured = {}
+
+        def side_effect(url, **kwargs):
+            if "appdetails" in url:
+                captured["params"] = kwargs.get("params", {})
+                return _mock_response(200, json_data=_make_appdetails_response("978520"))
+            if "search" in url:
+                return _mock_response(200, text=_make_search_html())
+            if "appreviews" in url:
+                return _mock_response(200, json_data=_make_appreviews_response())
+            return _mock_response(200, text="<html></html>")
+
+        with patch("modules.scrapers.steam.requests.get", side_effect=side_effect), \
+             patch("modules.scrapers.steam.STEAM_COUNTRY", "MX"):
+            SteamScraper().fetch_free_games()
+
+        assert captured.get("params", {}).get("cc") == "MX"
+
 
 class TestParseSteamEndDate:
     def test_parses_am_time(self, freeze_steam_now):


### PR DESCRIPTION
## Summary

- Adds `original_price` as a field in Discord embeds — shown when available, omitted gracefully when `None`. Includes English and Spanish translations ("Original Price" / "Precio original").
- Introduces `STEAM_COUNTRY` env var (default `"US"`) so Steam search and appdetails API calls use the configured country code, fixing prices being returned in USD regardless of the user's region. Documented in `.env.example` alongside `EPIC_GAMES_REGION`.
- Removes the hardcoded `"cc": "US"` from `_SEARCH_PARAMS` and `_fetch_appdetails`; both now resolve `STEAM_COUNTRY` at call time (same pattern as `STEAM_LANGUAGE`), making it fully patchable in tests.

Closes #107

## Test plan

- [x] `test_embed_shows_original_price_when_present` — price field appears with correct value
- [x] `test_embed_omits_original_price_when_none` — no price field when `original_price` is `None`
- [x] `test_embed_shows_original_price_label_in_spanish` — label uses Spanish translation
- [x] `test_search_uses_configured_country` — `cc=MX` passed to search when `STEAM_COUNTRY=MX`
- [x] `test_search_defaults_to_us_country` — `cc=US` by default
- [x] `test_appdetails_uses_configured_country` — `cc=MX` passed to appdetails when `STEAM_COUNTRY=MX`
- [x] All 75 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)