### PR TITLE
fix: remove duplicate translation keys and add STEAM_COUNTRY to compose (#107 follow-up)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -28,6 +28,7 @@ services:
       - ENABLED_STORES=${ENABLED_STORES:-epic}
       - STEAM_REQUEST_DELAY_MS=${STEAM_REQUEST_DELAY_MS:-1500}
       - STEAM_LANGUAGE=${STEAM_LANGUAGE:-english}
+      - STEAM_COUNTRY=${STEAM_COUNTRY:-US}
     image: free-games-notifier
     ports:
       - "${API_PORT:-8000}:${API_PORT:-8000}"

--- a/modules/notifier.py
+++ b/modules/notifier.py
@@ -19,9 +19,8 @@ _TRANSLATIONS = {
         "ends_on": "Ends on",
         "permanently_free": "Permanently free",
         "end_date_unavailable": "End date unavailable",
-        "original_price": "Original Price",
-        "user_reviews": "💬 User Reviews:",
         "original_price": "💰 Original Price",
+        "user_reviews": "💬 User Reviews:",
         "new_free_game": "**New Free Game on {store}! 🎮**\n",
         "new_free_games": "**New Free Games! 🎮**\n",
         "review_labels": {
@@ -41,9 +40,8 @@ _TRANSLATIONS = {
         "ends_on": "Finaliza el",
         "permanently_free": "Gratis de forma permanente",
         "end_date_unavailable": "Fecha de fin no disponible",
-        "original_price": "Precio original",
-        "user_reviews": "💬 Opiniones de usuarios:",
         "original_price": "💰 Precio original",
+        "user_reviews": "💬 Opiniones de usuarios:",
         "new_free_game": "**¡Nuevo Juego Gratis en {store}! 🎮**\n",
         "new_free_games": "**¡Nuevos Juegos Gratis! 🎮**\n",
         "review_labels": {
@@ -285,12 +283,6 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
                     emoji = _REVIEW_EMOJIS.get(key, "🎮")
                     label = _T["review_labels"].get(key, game.review_score)
                     embed["description"] += f"\n\n{_T['user_reviews']}\n{label} {emoji}\n\n"
-                if game.original_price:
-                    embed.setdefault("fields", []).append({
-                        "name": _T["original_price"],
-                        "value": game.original_price,
-                        "inline": True,
-                    })
                 embeds.append(embed)
             except (AttributeError, ValueError) as e:
                 logger.error(f"Error processing game data for embed: {str(e)} | Game data: {game}")

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -565,7 +565,7 @@ class TestSendDiscordMessage:
 
         _, kwargs = mock_post.call_args
         fields = kwargs["json"]["embeds"][0].get("fields", [])
-        assert any(f["name"] == "Precio original" for f in fields)
+        assert any(f["name"] == "💰 Precio original" for f in fields)
 
 
 class TestSendDiscordMessageWebhookOverride:


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #135 (feat #107):

- Remove duplicate `original_price` keys in `_TRANSLATIONS` (EN and ES dicts each had two entries for the same key; Python silently kept the last one, but it was a latent bug). Now each locale has exactly one entry with the emoji-prefixed label (`💰 Original Price` / `💰 Precio original`).
- Remove a duplicate `embed["fields"]` block that was accidentally introduced during a stash merge — the price field was being appended twice when both a price and a review score were present.
- Add `STEAM_COUNTRY` to `compose.yaml` so the container picks up the env var (without this, setting `STEAM_COUNTRY=MX` in `.env` had no effect on the running container).

## Test plan

- [x] 78/78 tests passing
- [x] No duplicate keys in `_TRANSLATIONS`
- [x] `STEAM_COUNTRY` now forwarded into the container via compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)