### PR TITLE
fix: sort games server-side before paginating in /games/history

### DIFF
--- a/api.py
+++ b/api.py
@@ -295,17 +295,32 @@ def games_latest():
 def games_history(
     limit: int = Query(default=20, ge=1, le=100, description="Max number of games to return"),
     offset: int = Query(default=0, ge=0, description="Number of games to skip"),
+    sort_by: str = Query(default="end_date", pattern="^(end_date|title)$", description="Field to sort by"),
+    sort_dir: str = Query(default="desc", pattern="^(asc|desc)$", description="Sort direction"),
 ):
     """Paginated access to all past fetched games.
 
     Query parameters:
     - **limit**: Max number of games to return (1–100, default: 20)
     - **offset**: Number of games to skip (default: 0)
+    - **sort_by**: Field to sort by — ``end_date`` (default) or ``title``
+    - **sort_dir**: Sort direction — ``desc`` (default) or ``asc``
+
+    Sorting is applied to the full dataset **before** pagination so that the
+    ordering is consistent across pages.
     """
     from modules.storage import load_previous_games
 
+    def _sort_key(game):
+        if sort_by == "title":
+            v = game.title if isinstance(game, FreeGame) else game.get("title", "")
+            return v.lower()
+        # end_date — ISO-8601 strings sort correctly as plain strings
+        return game.end_date if isinstance(game, FreeGame) else game.get("end_date", "")
+
     try:
         all_games = load_previous_games()
+        all_games.sort(key=_sort_key, reverse=(sort_dir == "desc"))
         total = len(all_games)
         page = all_games[offset : offset + limit]
         return {"games": [_to_game_item_dict(g) for g in page], "total": total, "limit": limit, "offset": offset}

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -24,7 +24,7 @@ export default function App() {
     setLoading(true)
     setError(null)
     try {
-      const res = await fetch(`/games/history?limit=${PAGE_SIZE}&offset=${offset}`)
+      const res = await fetch(`/games/history?limit=${PAGE_SIZE}&offset=${offset}&sort_by=${sortBy}&sort_dir=${sortDir}`)
       if (!res.ok) throw new Error(`Server responded with ${res.status}`)
       const data: GamesHistoryResponse = await res.json()
       setGames(data.games)
@@ -34,7 +34,7 @@ export default function App() {
     } finally {
       setLoading(false)
     }
-  }, [offset])
+  }, [offset, sortBy, sortDir])
 
   useEffect(() => {
     fetchGames()
@@ -53,25 +53,18 @@ export default function App() {
       setSortBy(field)
       setSortDir('desc')
     }
+    setPage(1)
   }
 
-  // Client-side filter + sort on the current page
-  const filtered = games
-    .filter(g => {
-      if (!search) return true
-      const q = search.toLowerCase()
-      return (
-        g.title.toLowerCase().includes(q) ||
-        g.description.toLowerCase().includes(q)
-      )
-    })
-    .sort((a, b) => {
-      const mul = sortDir === 'asc' ? 1 : -1
-      if (sortBy === 'title') return a.title.localeCompare(b.title) * mul
-      return (
-        (new Date(a.end_date).getTime() - new Date(b.end_date).getTime()) * mul
-      )
-    })
+  // Client-side filter only — sorting is done server-side before pagination
+  const filtered = games.filter(g => {
+    if (!search) return true
+    const q = search.toLowerCase()
+    return (
+      g.title.toLowerCase().includes(q) ||
+      g.description.toLowerCase().includes(q)
+    )
+  })
 
   const totalPages = Math.ceil(total / PAGE_SIZE)
 


### PR DESCRIPTION
## Summary

- Sorting was applied client-side on the current page only — games inserted later into the DB (e.g. from a second store) would appear on a different page, even if their `end_date` was more recent than games on page 1.
- Added `sort_by` and `sort_dir` query params to `GET /games/history` (defaults: `end_date desc`). The full list is sorted **before** slicing, so ordering is consistent across all pages.
- Dashboard now passes `sort_by` and `sort_dir` in every fetch request, and the `useCallback` dependency array includes both so a sort change triggers a fresh fetch.
- Removed the now-redundant client-side `.sort()` (client still filters by search term).
- Also reset to page 1 when the user changes the sort field/direction.

## Test plan

- [x] All 307 unit tests pass.
- [x] Rebuild container, verify page 1 shows the 4 active free games at the top sorted by end date descending.
- [x] Switch sort to Title / Ascending — verify page 1 changes immediately and is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)