### PR TITLE
ci: add release workflow (release.yml)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      attestations: write  # required for provenance attestation
+      id-token: write      # required for OIDC token used by attestation signing
 
     steps:
       - name: Checkout code
@@ -37,9 +39,10 @@ jobs:
           images: ghcr.io/juliomoralesb/free-games-notifier
           tags: |
             type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -49,3 +52,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Generate provenance attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/juliomoralesb/free-games-notifier
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/juliomoralesb/free-games-notifier
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## What changed

- Added `.github/workflows/release.yml` that triggers on any `v*.*.*` tag push
- Builds a multi-platform Docker image (`linux/amd64`, `linux/arm64`) for homelab ARM compatibility
- Pushes to `ghcr.io/juliomoralesb/free-games-notifier` with both a versioned tag (e.g. `v1.2.3`) and `:latest`
- Uses `docker/metadata-action` to extract semver from the Git tag automatically
- GitHub Actions cache (`type=gha`) speeds up subsequent builds
- No additional secrets needed — `GITHUB_TOKEN` has write access to the package registry by default

## How to test

1. Push a semver tag: `git tag v1.0.0 && git push origin v1.0.0`
2. Confirm the workflow runs under **Actions → Release**
3. Verify the image appears under **Packages** in the repo
4. Confirm it is publicly pullable: `docker pull ghcr.io/juliomoralesb/free-games-notifier:latest`

Closes #126