### PR TITLE
fix(migration): use ->> in 0008 downgrade to avoid quoted strings

### DIFF
--- a/alembic/versions/0008_review_scores_array.py
+++ b/alembic/versions/0008_review_scores_array.py
@@ -58,7 +58,7 @@ def downgrade() -> None:
         UPDATE free_games.games
         SET review_score = CASE
             WHEN review_scores IS NOT NULL AND review_scores <> '[]'
-                THEN (review_scores::json->0)::text
+                THEN review_scores::json->>0
             ELSE NULL
         END
     """)


### PR DESCRIPTION
## Summary

- Fixes a bug in the `downgrade()` path of migration `0008_review_scores_array`
- `json->0` returns the first array element as a **JSON value** (e.g. `"Very Positive"` with surrounding double-quotes)
- `json->>0` returns it as **plain TEXT** (`Very Positive`), which is what the old `review_score` column expects
- The `::text` cast after `->0` did not strip the quotes

## What was wrong

```sql
-- Before (broken): writes '"Very Positive"' (with quotes)
THEN (review_scores::json->0)::text

-- After (correct): writes 'Very Positive'
THEN review_scores::json->>0
```

## Notes

Issue 1 from the PR review (Metacritic JSON-LD removed) was verified as **incorrect** — both `celeste` and `doomblade` pages still serve `aggregateRating.ratingValue` in their JSON-LD block as of today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)