### PR TITLE
feat: dashboard status/store filters, countdown, reviews & original price (#71, #115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A Python-based scheduler that monitors the Epic Games Store and Steam for free g
 ## Features
 
 - ✅ **Multi-Store Monitoring**: Checks Epic Games Store and Steam for free games — on a daily schedule or a configurable repeating interval
-- 💬 **Discord Notifications**: Sends beautifully formatted Discord embeds with game details, original price, and user review score
+- 💬 **Discord Notifications**: Sends beautifully formatted Discord embeds with game details, original price, and review scores (Steam user reviews + Metacritic)
 - 📊 **Persistent Storage**: Maintains game history — PostgreSQL when `DB_HOST` is set, JSON file otherwise
 - 🏥 **Health Checks**: Optional UptimeKuma/Healthchecks.io integration for monitoring
-- 🌐 **Web Dashboard**: Browse and search the full history of tracked free games at `/dashboard/`
+- 🌐 **Web Dashboard**: Browse, filter, and search the full history of tracked free games at `/dashboard/`
 - 🔌 **REST API**: Built-in FastAPI endpoints for health, history, metrics, and notification management
 - 🐳 **Docker Ready**: Includes Docker and docker-compose configurations
 - 🌍 **Fully Configurable**: Set `REGION` to a single IANA timezone string and get timezone, locale, Steam language, and Steam country all at once — or configure each variable individually
@@ -135,12 +135,16 @@ The dashboard is a React/TypeScript SPA served at **`http://<host>:<API_PORT>/da
 
 ![Web Dashboard](https://github.com/user-attachments/assets/1ffef230-45e2-4ef1-9ffb-6a7a9d573d62)
 
-- Game cards with thumbnail, title, description, promotion end date, and Epic Games Store link
-- Live search by title or description
+- Game cards with thumbnail, title, description, original price, review scores, and promotion end date
+- **Status filter**: tabs to view "Currently Free", "Previously Free", or all games
+- **Store filter**: pill buttons to filter by All / Epic Games / Steam
+- Countdown timer on active promotions; expired cards are visually dimmed
+- Live search by title or description (client-side, within the current page)
 - Sort by date or title
-- Server-side pagination with smart ellipsis
+- Server-side pagination with smart ellipsis (filters applied before paginating)
 - Responsive dark theme, no external UI framework
 - English and Spanish built-in; browser language auto-detected; preference persisted in `localStorage`
+- Filter selections (status, store) persisted in `sessionStorage`
 
 For development setup, hot-reload, and adding new languages, see [docs/dashboard.md](docs/dashboard.md).
 
@@ -265,9 +269,9 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 - [x] Support for additional game stores — Steam (#56)
 - [x] Display original price and Steam country-specific pricing (#107)
 - [x] Unified `REGION` variable — one setting derives timezone, locale, and all store options (#117)
-- [ ] Show user reviews for Epic Games Store games (#106)
-- [ ] Differentiate DLCs from base games in notifications and dashboard (#109)
-- [ ] Store filter in the web dashboard (#115)
+- [x] Show review scores (Steam + Metacritic) in notifications and dashboard (#106)
+- [x] Differentiate DLCs from base games in notifications and dashboard (#109)
+- [x] Store filter in the web dashboard (#115)
+- [x] UI/UX Enhancements: status filter tabs, countdown timer, original price, review scores, expired card styling (#71)
 - [ ] Add support for multiple notification channels (Discord, Slack, Telegram, etc.) (#55)
-- [ ] UI/UX Enhancements (#71)
 

--- a/api.py
+++ b/api.py
@@ -338,11 +338,12 @@ def games_history(
     try:
         all_games = load_previous_games()
 
-        # Apply store filter
+        # Apply store filter — legacy dict records without a "store" key default to
+        # "epic" to match the same fallback used in _to_game_item_dict serialization.
         if store != "all":
             all_games = [
                 g for g in all_games
-                if (g.store if isinstance(g, FreeGame) else g.get("store", "")) == store
+                if (g.store if isinstance(g, FreeGame) else g.get("store", "epic")) == store
             ]
 
         # Apply status filter

--- a/api.py
+++ b/api.py
@@ -4,6 +4,7 @@ import os
 import threading
 import time
 import logging
+from datetime import datetime, timezone
 from typing import List, Optional
 
 import requests as requests_lib
@@ -49,7 +50,8 @@ class GameItem(BaseModel):
     description: str = Field(..., description="Short description of the game")
     thumbnail: str = Field(..., description="URL to the game's thumbnail image")
     game_type: str = Field("game", description="Content type: 'game' or 'dlc'", examples=["game", "dlc"])
-    review_scores: List[str] = Field(default_factory=list, description="Review scores from available sources", examples=[["Very Positive", "Metascore: 83", "OpenCritic: 78"]])
+    original_price: Optional[str] = Field(default=None, description="Original retail price before the free promotion", examples=["$19.99", "€14.99"])
+    review_scores: List[str] = Field(default_factory=list, description="Review scores from available sources", examples=[["Very Positive", "Metascore: 83"]])
 
 
 class HealthResponse(BaseModel):
@@ -169,6 +171,7 @@ def _to_game_item_dict(game) -> dict:
             "description": game.description,
             "thumbnail": game.image_url,
             "game_type": game.game_type,
+            "original_price": game.original_price,
             "review_scores": game.review_scores,
         }
     # Legacy dict format – ensure store key is present with a safe default.
@@ -299,6 +302,8 @@ def games_history(
     offset: int = Query(default=0, ge=0, description="Number of games to skip"),
     sort_by: str = Query(default="end_date", pattern="^(end_date|title)$", description="Field to sort by"),
     sort_dir: str = Query(default="desc", pattern="^(asc|desc)$", description="Sort direction"),
+    store: str = Query(default="all", pattern="^(all|epic|steam)$", description="Filter by store: 'all', 'epic', or 'steam'"),
+    status: str = Query(default="all", pattern="^(all|active|expired)$", description="Filter by promotion status: 'all', 'active' (end_date in the future), or 'expired'"),
 ):
     """Paginated access to all past fetched games.
 
@@ -307,11 +312,21 @@ def games_history(
     - **offset**: Number of games to skip (default: 0)
     - **sort_by**: Field to sort by — ``end_date`` (default) or ``title``
     - **sort_dir**: Sort direction — ``desc`` (default) or ``asc``
+    - **store**: Store filter — ``all`` (default), ``epic``, or ``steam``
+    - **status**: Promotion status filter — ``all`` (default), ``active`` (promotion still live), or ``expired``
 
-    Sorting is applied to the full dataset **before** pagination so that the
-    ordering is consistent across pages.
+    Filtering and sorting are applied to the full dataset **before** pagination
+    so that counts and ordering are consistent across pages.
     """
     from modules.storage import load_previous_games
+
+    def _get_end_date(game) -> datetime:
+        """Return the game's end_date as an aware UTC datetime, or datetime.min on parse error."""
+        try:
+            raw = game.end_date if isinstance(game, FreeGame) else game.get("end_date", "")
+            return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except Exception:
+            return datetime.min.replace(tzinfo=timezone.utc)
 
     def _sort_key(game):
         if sort_by == "title":
@@ -322,6 +337,22 @@ def games_history(
 
     try:
         all_games = load_previous_games()
+
+        # Apply store filter
+        if store != "all":
+            all_games = [
+                g for g in all_games
+                if (g.store if isinstance(g, FreeGame) else g.get("store", "")) == store
+            ]
+
+        # Apply status filter
+        if status != "all":
+            now = datetime.now(timezone.utc)
+            if status == "active":
+                all_games = [g for g in all_games if _get_end_date(g) > now]
+            else:  # expired
+                all_games = [g for g in all_games if _get_end_date(g) <= now]
+
         all_games.sort(key=_sort_key, reverse=(sort_dir == "desc"))
         total = len(all_games)
         page = all_games[offset : offset + limit]

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -15,12 +15,22 @@ export default function App() {
   const [search, setSearch] = useState('')
   const [sortBy, setSortBy] = useState<SortField>('end_date')
   const [sortDir, setSortDir] = useState<SortDirection>('desc')
-  const [storeFilter, setStoreFilter] = useState<StoreFilter>(
-    () => (sessionStorage.getItem('storeFilter') as StoreFilter) || 'all'
-  )
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>(
-    () => (sessionStorage.getItem('statusFilter') as StatusFilter) || 'all'
-  )
+  const [storeFilter, setStoreFilter] = useState<StoreFilter>(() => {
+    try {
+      return (sessionStorage.getItem('storeFilter') as StoreFilter) || 'all'
+    } catch {
+      // sessionStorage unavailable (restricted privacy settings, etc.)
+      return 'all'
+    }
+  })
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>(() => {
+    try {
+      return (sessionStorage.getItem('statusFilter') as StatusFilter) || 'all'
+    } catch {
+      // sessionStorage unavailable
+      return 'all'
+    }
+  })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -28,11 +38,19 @@ export default function App() {
 
   // Persist filter selections across page refreshes within the same session
   useEffect(() => {
-    sessionStorage.setItem('storeFilter', storeFilter)
+    try {
+      sessionStorage.setItem('storeFilter', storeFilter)
+    } catch {
+      // sessionStorage unavailable — persistence is best-effort
+    }
   }, [storeFilter])
 
   useEffect(() => {
-    sessionStorage.setItem('statusFilter', statusFilter)
+    try {
+      sessionStorage.setItem('statusFilter', statusFilter)
+    } catch {
+      // sessionStorage unavailable — persistence is best-effort
+    }
   }, [statusFilter])
 
   const fetchGames = useCallback(async () => {

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import type { GameItem, GamesHistoryResponse, SortField, SortDirection } from './types'
+import type { GameItem, GamesHistoryResponse, SortField, SortDirection, StoreFilter, StatusFilter } from './types'
 import GameCard from './components/GameCard'
 import Pagination from './components/Pagination'
 import LanguageSelector from './components/LanguageSelector'
@@ -15,16 +15,35 @@ export default function App() {
   const [search, setSearch] = useState('')
   const [sortBy, setSortBy] = useState<SortField>('end_date')
   const [sortDir, setSortDir] = useState<SortDirection>('desc')
+  const [storeFilter, setStoreFilter] = useState<StoreFilter>(
+    () => (sessionStorage.getItem('storeFilter') as StoreFilter) || 'all'
+  )
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>(
+    () => (sessionStorage.getItem('statusFilter') as StatusFilter) || 'all'
+  )
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   const offset = (page - 1) * PAGE_SIZE
 
+  // Persist filter selections across page refreshes within the same session
+  useEffect(() => {
+    sessionStorage.setItem('storeFilter', storeFilter)
+  }, [storeFilter])
+
+  useEffect(() => {
+    sessionStorage.setItem('statusFilter', statusFilter)
+  }, [statusFilter])
+
   const fetchGames = useCallback(async () => {
     setLoading(true)
     setError(null)
     try {
-      const res = await fetch(`/games/history?limit=${PAGE_SIZE}&offset=${offset}&sort_by=${sortBy}&sort_dir=${sortDir}`)
+      const url =
+        `/games/history?limit=${PAGE_SIZE}&offset=${offset}` +
+        `&sort_by=${sortBy}&sort_dir=${sortDir}` +
+        `&store=${storeFilter}&status=${statusFilter}`
+      const res = await fetch(url)
       if (!res.ok) throw new Error(`Server responded with ${res.status}`)
       const data: GamesHistoryResponse = await res.json()
       setGames(data.games)
@@ -34,7 +53,7 @@ export default function App() {
     } finally {
       setLoading(false)
     }
-  }, [offset, sortBy, sortDir])
+  }, [offset, sortBy, sortDir, storeFilter, statusFilter])
 
   useEffect(() => {
     fetchGames()
@@ -56,7 +75,17 @@ export default function App() {
     setPage(1)
   }
 
-  // Client-side filter only — sorting is done server-side before pagination
+  const handleStoreFilter = (store: StoreFilter) => {
+    setStoreFilter(store)
+    setPage(1)
+  }
+
+  const handleStatusFilter = (status: StatusFilter) => {
+    setStatusFilter(status)
+    setPage(1)
+  }
+
+  // Client-side search filter — sorting and store/status filtering are done server-side
   const filtered = games.filter(g => {
     if (!search) return true
     const q = search.toLowerCase()
@@ -87,6 +116,20 @@ export default function App() {
     </button>
   )
 
+  const getEmptyIcon = () => {
+    if (search) return '🔍'
+    if (statusFilter === 'active') return '🎮'
+    if (statusFilter === 'expired') return '🏛️'
+    return '🕹️'
+  }
+
+  const getEmptyMessage = () => {
+    if (search) return t.noGamesMatch(search)
+    if (statusFilter === 'active') return t.noActiveGames
+    if (statusFilter === 'expired') return t.noExpiredGames
+    return t.noGamesYet
+  }
+
   return (
     <div className="app">
       <header className="header">
@@ -110,6 +153,41 @@ export default function App() {
       </header>
 
       <main className="main">
+        {/* Filter bar: status tabs + store pills */}
+        <div className="filter-bar">
+          <div className="filter-group">
+            <span className="filter-label">{t.statusFilterLabel}</span>
+            <div className="filter-tabs">
+              {(['all', 'active', 'expired'] as StatusFilter[]).map(s => (
+                <button
+                  key={s}
+                  className={`filter-tab${statusFilter === s ? ' active' : ''}`}
+                  onClick={() => handleStatusFilter(s)}
+                  aria-pressed={statusFilter === s}
+                >
+                  {s === 'all' ? t.statusAll : s === 'active' ? t.statusActive : t.statusExpired}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="filter-group">
+            <span className="filter-label">{t.storeFilterLabel}</span>
+            <div className="filter-tabs">
+              {(['all', 'epic', 'steam'] as StoreFilter[]).map(s => (
+                <button
+                  key={s}
+                  className={`filter-tab${storeFilter === s ? ' active' : ''}`}
+                  onClick={() => handleStoreFilter(s)}
+                  aria-pressed={storeFilter === s}
+                >
+                  {s === 'all' ? t.storeAll : s === 'epic' ? t.storeEpic : t.storeSteam}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
         <div className="toolbar">
           <div className="search-wrapper">
             <span className="search-icon">🔍</span>
@@ -157,12 +235,8 @@ export default function App() {
 
         {!loading && !error && filtered.length === 0 && (
           <div className="state-container">
-            <span className="state-icon">🕹️</span>
-            <p>
-              {search
-                ? t.noGamesMatch(search)
-                : t.noGamesYet}
-            </p>
+            <span className="state-icon">{getEmptyIcon()}</span>
+            <p>{getEmptyMessage()}</p>
           </div>
         )}
 

--- a/dashboard/src/components/GameCard.tsx
+++ b/dashboard/src/components/GameCard.tsx
@@ -26,6 +26,15 @@ const STEAM_REVIEW_EMOJIS: Record<string, string> = {
   'overwhelmingly negative': '💀',
 }
 
+/**
+ * Steam labels that indicate no meaningful score data — omitted from the UI
+ * rather than shown as an unhelpful chip.
+ */
+const STEAM_NO_DATA_LABELS = new Set([
+  'no user reviews',
+  'no reviews',
+])
+
 /** Metacritic score value → display emoji */
 function metacriticEmoji(score: number): string {
   if (score >= 90) return '🏆'
@@ -98,7 +107,7 @@ export default function GameCard({ game }: Props) {
         {isPastPromotion && (
           <div className="card-expired-overlay" aria-hidden="true">
             <span className="card-expired-label">
-              {t.wasFreeUntil}
+              {t.expiredBadge}
             </span>
           </div>
         )}
@@ -128,25 +137,31 @@ export default function GameCard({ game }: Props) {
           </p>
         )}
 
-        {/* Review scores */}
-        {game.review_scores && game.review_scores.length > 0 && (
+        {/* Review scores — skip non-informative Steam labels like "No user reviews" */}
+        {game.review_scores && game.review_scores.some(s =>
+          s.startsWith('Metascore: ') || !STEAM_NO_DATA_LABELS.has(s.toLowerCase())
+        ) && (
           <div className="card-reviews">
-            {game.review_scores.map((score, i) => {
-              if (score.startsWith('Metascore: ')) {
-                const val = parseInt(score.replace('Metascore: ', ''), 10)
+            {game.review_scores
+              .filter(score =>
+                score.startsWith('Metascore: ') || !STEAM_NO_DATA_LABELS.has(score.toLowerCase())
+              )
+              .map((score, i) => {
+                if (score.startsWith('Metascore: ')) {
+                  const val = parseInt(score.replace('Metascore: ', ''), 10)
+                  return (
+                    <span key={i} className="card-review card-review--meta">
+                      {metacriticEmoji(val)} {score}
+                    </span>
+                  )
+                }
+                const emoji = STEAM_REVIEW_EMOJIS[score.toLowerCase()] ?? '🎮'
                 return (
-                  <span key={i} className="card-review card-review--meta">
-                    {metacriticEmoji(val)} {score}
+                  <span key={i} className="card-review card-review--steam">
+                    {emoji} {score}
                   </span>
                 )
-              }
-              const emoji = STEAM_REVIEW_EMOJIS[score.toLowerCase()] ?? '🎮'
-              return (
-                <span key={i} className="card-review card-review--steam">
-                  {emoji} {score}
-                </span>
-              )
-            })}
+              })}
           </div>
         )}
 

--- a/dashboard/src/components/GameCard.tsx
+++ b/dashboard/src/components/GameCard.tsx
@@ -51,7 +51,10 @@ interface TimeLeft {
 }
 
 function calcTimeLeft(endDate: string): TimeLeft | null {
-  const diff = new Date(endDate).getTime() - Date.now()
+  if (!endDate) return null
+  const ms = new Date(endDate).getTime()
+  if (isNaN(ms)) return null
+  const diff = ms - Date.now()
   if (diff <= 0) return null
   const days    = Math.floor(diff / 86_400_000)
   const hours   = Math.floor((diff % 86_400_000) / 3_600_000)
@@ -64,7 +67,10 @@ interface Props {
 }
 
 function formatDate(iso: string, locale: Locale): string {
+  if (!iso) return '—'
   try {
+    const date = new Date(iso)
+    if (isNaN(date.getTime())) return '—'
     return new Intl.DateTimeFormat(localeBcp47[locale], {
       year: 'numeric',
       month: 'short',
@@ -72,7 +78,7 @@ function formatDate(iso: string, locale: Locale): string {
       hour: '2-digit',
       minute: '2-digit',
       timeZoneName: 'short',
-    }).format(new Date(iso))
+    }).format(date)
   } catch {
     return iso
   }
@@ -83,7 +89,9 @@ export default function GameCard({ game }: Props) {
   const [imgError, setImgError] = useState(false)
   const [timeLeft, setTimeLeft] = useState<TimeLeft | null>(() => calcTimeLeft(game.end_date))
 
-  const isPastPromotion = new Date(game.end_date) < new Date()
+  // Treat missing or unparseable end_date as expired
+  const endMs = game.end_date ? new Date(game.end_date).getTime() : NaN
+  const isPastPromotion = isNaN(endMs) || endMs < Date.now()
   const storeMeta = getStoreMeta(game.store)
   const isDlc = game.game_type === 'dlc'
 

--- a/dashboard/src/components/GameCard.tsx
+++ b/dashboard/src/components/GameCard.tsx
@@ -155,10 +155,12 @@ export default function GameCard({ game }: Props) {
                     </span>
                   )
                 }
-                const emoji = STEAM_REVIEW_EMOJIS[score.toLowerCase()] ?? '🎮'
+                const key = score.toLowerCase()
+                const emoji = STEAM_REVIEW_EMOJIS[key] ?? '🎮'
+                const label = t.steamReviewLabels[key] ?? score
                 return (
                   <span key={i} className="card-review card-review--steam">
-                    {emoji} {score}
+                    {emoji} {label}
                   </span>
                 )
               })}

--- a/dashboard/src/components/GameCard.tsx
+++ b/dashboard/src/components/GameCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import type { GameItem } from '../types'
 import { useTranslation } from '../i18n'
 import type { Locale } from '../i18n/translations'
@@ -11,6 +11,43 @@ const STORE_META: Record<string, { label: string; icon: string }> = {
 
 function getStoreMeta(store: string) {
   return STORE_META[store] ?? { label: store, icon: '🏪' }
+}
+
+/** Steam user-review label → display emoji */
+const STEAM_REVIEW_EMOJIS: Record<string, string> = {
+  'overwhelmingly positive': '🔥',
+  'very positive':           '😄',
+  'mostly positive':         '👍',
+  'positive':                '👍',
+  'mixed':                   '😐',
+  'mostly negative':         '👎',
+  'negative':                '👎',
+  'very negative':           '😞',
+  'overwhelmingly negative': '💀',
+}
+
+/** Metacritic score value → display emoji */
+function metacriticEmoji(score: number): string {
+  if (score >= 90) return '🏆'
+  if (score >= 75) return '⭐'
+  if (score >= 61) return '👍'
+  if (score >= 40) return '⚖️'
+  return '👎'
+}
+
+interface TimeLeft {
+  days: number
+  hours: number
+  minutes: number
+}
+
+function calcTimeLeft(endDate: string): TimeLeft | null {
+  const diff = new Date(endDate).getTime() - Date.now()
+  if (diff <= 0) return null
+  const days    = Math.floor(diff / 86_400_000)
+  const hours   = Math.floor((diff % 86_400_000) / 3_600_000)
+  const minutes = Math.floor((diff % 3_600_000) / 60_000)
+  return { days, hours, minutes }
 }
 
 interface Props {
@@ -35,18 +72,35 @@ function formatDate(iso: string, locale: Locale): string {
 export default function GameCard({ game }: Props) {
   const { t, locale } = useTranslation()
   const [imgError, setImgError] = useState(false)
+  const [timeLeft, setTimeLeft] = useState<TimeLeft | null>(() => calcTimeLeft(game.end_date))
 
   const isPastPromotion = new Date(game.end_date) < new Date()
   const storeMeta = getStoreMeta(game.store)
   const isDlc = game.game_type === 'dlc'
 
+  // Countdown: update every minute for active promotions
+  useEffect(() => {
+    if (isPastPromotion) return
+    const timer = setInterval(() => {
+      setTimeLeft(calcTimeLeft(game.end_date))
+    }, 60_000)
+    return () => clearInterval(timer)
+  }, [game.end_date, isPastPromotion])
+
   return (
-    <article className="card">
+    <article className={`card${isPastPromotion ? ' card--expired' : ''}`}>
       <div className="card-image-wrapper">
         {isDlc && (
           <span className="card-dlc-badge" aria-label={t.dlcBadge}>
             {t.dlcBadge}
           </span>
+        )}
+        {isPastPromotion && (
+          <div className="card-expired-overlay" aria-hidden="true">
+            <span className="card-expired-label">
+              {t.wasFreeUntil}
+            </span>
+          </div>
         )}
         {game.thumbnail && !imgError ? (
           <img
@@ -74,7 +128,38 @@ export default function GameCard({ game }: Props) {
           </p>
         )}
 
+        {/* Review scores */}
+        {game.review_scores && game.review_scores.length > 0 && (
+          <div className="card-reviews">
+            {game.review_scores.map((score, i) => {
+              if (score.startsWith('Metascore: ')) {
+                const val = parseInt(score.replace('Metascore: ', ''), 10)
+                return (
+                  <span key={i} className="card-review card-review--meta">
+                    {metacriticEmoji(val)} {score}
+                  </span>
+                )
+              }
+              const emoji = STEAM_REVIEW_EMOJIS[score.toLowerCase()] ?? '🎮'
+              return (
+                <span key={i} className="card-review card-review--steam">
+                  {emoji} {score}
+                </span>
+              )
+            })}
+          </div>
+        )}
+
         <div className="card-meta">
+          {/* Original price */}
+          {game.original_price && (
+            <div className="card-price">
+              <span className="card-price-label">{t.originalPrice}</span>
+              <span className="card-price-value">{game.original_price}</span>
+            </div>
+          )}
+
+          {/* Countdown or date */}
           <div className="card-date">
             <span className="card-date-icon">📅</span>
             <span>
@@ -82,6 +167,16 @@ export default function GameCard({ game }: Props) {
               {formatDate(game.end_date, locale)}
             </span>
           </div>
+
+          {/* Active countdown badge */}
+          {!isPastPromotion && timeLeft && (
+            <div className="card-countdown">
+              {timeLeft.days === 0 && timeLeft.hours < 6
+                ? t.expiresSoon
+                : t.timeLeft(timeLeft.days, timeLeft.hours, timeLeft.minutes)}
+            </div>
+          )}
+
           <span className="card-store">{storeMeta.icon} {storeMeta.label}</span>
         </div>
       </div>

--- a/dashboard/src/i18n/translations.ts
+++ b/dashboard/src/i18n/translations.ts
@@ -39,6 +39,7 @@ export interface Translations {
   freeUntil: string
   viewOnStore: (storeName: string) => string
   dlcBadge: string
+  expiredBadge: string
   originalPrice: string
   timeLeft: (days: number, hours: number, minutes: number) => string
   expiresSoon: string
@@ -95,6 +96,7 @@ const en: Translations = {
   freeUntil: 'Free until',
   viewOnStore: (storeName) => `View on ${storeName} →`,
   dlcBadge: 'DLC',
+  expiredBadge: 'Expired',
   originalPrice: 'Original price:',
   timeLeft: (days, hours, minutes) =>
     days > 0
@@ -156,6 +158,7 @@ const es: Translations = {
   freeUntil: 'Gratis hasta el',
   viewOnStore: (storeName) => `Ver en ${storeName} →`,
   dlcBadge: 'DLC',
+  expiredBadge: 'Expirado',
   originalPrice: 'Precio original:',
   timeLeft: (days, hours, minutes) =>
     days > 0

--- a/dashboard/src/i18n/translations.ts
+++ b/dashboard/src/i18n/translations.ts
@@ -14,17 +14,34 @@ export interface Translations {
   sortByDate: string
   sortByTitle: string
 
+  // Filter bar — status
+  statusFilterLabel: string
+  statusAll: string
+  statusActive: string
+  statusExpired: string
+
+  // Filter bar — store
+  storeFilterLabel: string
+  storeAll: string
+  storeEpic: string
+  storeSteam: string
+
   // Loading / error / empty states
   loadingGames: string
   errorRetry: string
   noGamesMatch: (query: string) => string
   noGamesYet: string
+  noActiveGames: string
+  noExpiredGames: string
 
   // GameCard
   wasFreeUntil: string
   freeUntil: string
   viewOnStore: (storeName: string) => string
   dlcBadge: string
+  originalPrice: string
+  timeLeft: (days: number, hours: number, minutes: number) => string
+  expiresSoon: string
 
   // Pagination
   paginationNavAriaLabel: string
@@ -53,17 +70,39 @@ const en: Translations = {
   sortByDate: 'Date',
   sortByTitle: 'Title',
 
+  // Filter bar — status
+  statusFilterLabel: 'Status:',
+  statusAll: 'All',
+  statusActive: 'Currently Free',
+  statusExpired: 'Previously Free',
+
+  // Filter bar — store
+  storeFilterLabel: 'Store:',
+  storeAll: 'All',
+  storeEpic: 'Epic',
+  storeSteam: 'Steam',
+
   // Loading / error / empty states
   loadingGames: 'Loading games…',
   errorRetry: 'Retry',
   noGamesMatch: (query) => `No games match "${query}"`,
   noGamesYet: 'No games in history yet.',
+  noActiveGames: 'No free games currently available.',
+  noExpiredGames: 'No previously free games found.',
 
   // GameCard
   wasFreeUntil: 'Was free until',
   freeUntil: 'Free until',
   viewOnStore: (storeName) => `View on ${storeName} →`,
   dlcBadge: 'DLC',
+  originalPrice: 'Original price:',
+  timeLeft: (days, hours, minutes) =>
+    days > 0
+      ? `⏰ ${days}d ${hours}h left`
+      : hours > 0
+        ? `⏰ ${hours}h ${minutes}m left`
+        : `⏰ ${minutes}m left`,
+  expiresSoon: '⏰ Expires soon!',
 
   // Pagination
   paginationNavAriaLabel: 'Pagination',
@@ -92,17 +131,39 @@ const es: Translations = {
   sortByDate: 'Fecha',
   sortByTitle: 'Título',
 
+  // Filter bar — status
+  statusFilterLabel: 'Estado:',
+  statusAll: 'Todos',
+  statusActive: 'Gratis Ahora',
+  statusExpired: 'Anteriores',
+
+  // Filter bar — store
+  storeFilterLabel: 'Tienda:',
+  storeAll: 'Todas',
+  storeEpic: 'Epic',
+  storeSteam: 'Steam',
+
   // Loading / error / empty states
   loadingGames: 'Cargando juegos…',
   errorRetry: 'Reintentar',
   noGamesMatch: (query) => `No se encontraron juegos para "${query}"`,
   noGamesYet: 'Aún no hay juegos en el historial.',
+  noActiveGames: 'No hay juegos gratis disponibles en este momento.',
+  noExpiredGames: 'No se encontraron juegos anteriormente gratuitos.',
 
   // GameCard
   wasFreeUntil: 'Estuvo gratis hasta el',
   freeUntil: 'Gratis hasta el',
   viewOnStore: (storeName) => `Ver en ${storeName} →`,
   dlcBadge: 'DLC',
+  originalPrice: 'Precio original:',
+  timeLeft: (days, hours, minutes) =>
+    days > 0
+      ? `⏰ Quedan ${days}d ${hours}h`
+      : hours > 0
+        ? `⏰ Quedan ${hours}h ${minutes}m`
+        : `⏰ Quedan ${minutes}m`,
+  expiresSoon: '⏰ ¡Expira pronto!',
 
   // Pagination
   paginationNavAriaLabel: 'Paginación',

--- a/dashboard/src/i18n/translations.ts
+++ b/dashboard/src/i18n/translations.ts
@@ -55,6 +55,9 @@ export interface Translations {
 
   // Language selector
   languageLabel: string
+
+  /** Localized display text for Steam user-review labels (keyed by lowercase English label). */
+  steamReviewLabels: Record<string, string>
 }
 
 const en: Translations = {
@@ -117,6 +120,18 @@ const en: Translations = {
 
   // Language selector
   languageLabel: 'Language',
+
+  steamReviewLabels: {
+    'overwhelmingly positive': 'Overwhelmingly Positive',
+    'very positive':           'Very Positive',
+    'mostly positive':         'Mostly Positive',
+    'positive':                'Positive',
+    'mixed':                   'Mixed',
+    'mostly negative':         'Mostly Negative',
+    'negative':                'Negative',
+    'very negative':           'Very Negative',
+    'overwhelmingly negative': 'Overwhelmingly Negative',
+  },
 }
 
 const es: Translations = {
@@ -179,6 +194,18 @@ const es: Translations = {
 
   // Language selector
   languageLabel: 'Idioma',
+
+  steamReviewLabels: {
+    'overwhelmingly positive': 'Abrumadoramente Positivo',
+    'very positive':           'Muy Positivo',
+    'mostly positive':         'Mayormente Positivo',
+    'positive':                'Positivo',
+    'mixed':                   'Mixto',
+    'mostly negative':         'Mayormente Negativo',
+    'negative':                'Negativo',
+    'very negative':           'Muy Negativo',
+    'overwhelmingly negative': 'Abrumadoramente Negativo',
+  },
 }
 
 export const translations: Record<Locale, Translations> = { en, es }

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -177,6 +177,61 @@ a:hover {
 }
 
 /* ============================================================
+   Filter bar (status tabs + store pills)
+   ============================================================ */
+.filter-bar {
+  display: flex;
+  gap: 1.25rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.filter-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.filter-label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.filter-tabs {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.filter-tab {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all var(--transition);
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.filter-tab:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.filter-tab.active {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+  color: var(--accent-light);
+  font-weight: 600;
+}
+
+/* ============================================================
    Toolbar (search + sort)
    ============================================================ */
 .toolbar {
@@ -443,6 +498,107 @@ a:hover {
   transform: translateY(-1px);
 }
 
+/* Expired card visual state */
+.card--expired {
+  opacity: 0.72;
+}
+
+.card--expired:hover {
+  opacity: 0.92;
+  border-color: rgba(156, 163, 175, 0.3);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.card--expired .card-link {
+  background: var(--text-dim);
+}
+
+.card--expired .card-link:hover {
+  background: var(--text-muted);
+}
+
+/* Expired overlay on card image */
+.card-expired-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.48);
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-start;
+  padding: 0.5rem;
+  z-index: 2;
+}
+
+.card-expired-label {
+  background: rgba(107, 114, 128, 0.9);
+  color: #fff;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+}
+
+/* Countdown badge */
+.card-countdown {
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: var(--success);
+  letter-spacing: 0.01em;
+}
+
+/* Original price row */
+.card-price {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  color: var(--text-dim);
+}
+
+.card-price-label {
+  color: var(--text-muted);
+}
+
+.card-price-value {
+  color: var(--text);
+  font-weight: 600;
+  text-decoration: line-through;
+  text-decoration-color: var(--danger);
+}
+
+/* Review scores */
+.card-reviews {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 0.1rem;
+}
+
+.card-review {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.76rem;
+  font-weight: 500;
+  border-radius: 4px;
+  padding: 0.18rem 0.5rem;
+  width: fit-content;
+}
+
+.card-review--steam {
+  background: rgba(103, 193, 245, 0.1);
+  color: #67c1f5;
+  border: 1px solid rgba(103, 193, 245, 0.2);
+}
+
+.card-review--meta {
+  background: rgba(255, 200, 0, 0.1);
+  color: #f5c518;
+  border: 1px solid rgba(255, 200, 0, 0.2);
+}
+
 /* ============================================================
    State containers (loading / error / empty)
    ============================================================ */
@@ -563,6 +719,11 @@ a:hover {
 @media (max-width: 640px) {
   .header-title h1 {
     font-size: 1.2rem;
+  }
+
+  .filter-bar {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .toolbar {

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -7,6 +7,10 @@ export interface GameItem {
   store: string;
   /** 'game' (default) or 'dlc' */
   game_type?: string;
+  /** Original retail price before the free promotion (e.g. "$19.99") */
+  original_price?: string;
+  /** Review scores from all available sources (Steam user labels, Metascore strings) */
+  review_scores?: string[];
 }
 
 export interface GamesHistoryResponse {
@@ -18,3 +22,9 @@ export interface GamesHistoryResponse {
 
 export type SortField = 'title' | 'end_date';
 export type SortDirection = 'asc' | 'desc';
+
+/** Server-side store filter */
+export type StoreFilter = 'all' | 'epic' | 'steam';
+
+/** Server-side promotion-status filter */
+export type StatusFilter = 'all' | 'active' | 'expired';

--- a/modules/scrapers/steam.py
+++ b/modules/scrapers/steam.py
@@ -208,6 +208,12 @@ class SteamScraper(BaseScraper):
             f"/steam/apps/{appid}/capsule_sm_120.jpg"
         )
         end_date = self._fetch_end_date(candidate["url"])
+        if not end_date:
+            logger.error(
+                "END DATE MISSING for Steam game %r (appid=%s, url=%s). "
+                "Game will be stored with empty end_date — check the store page manually.",
+                title, appid, candidate["url"],
+            )
 
         # The appdetails API returns a "type" field: "game", "dlc", "music", etc.
         # This is more reliable than inferring from search-result CSS classes.
@@ -288,8 +294,9 @@ class SteamScraper(BaseScraper):
                 result = _parse_steam_end_date(el.text)
                 if result:
                     return result
-                logger.warning(
-                    "Found .game_purchase_discount_quantity but could not parse end date. "
+                logger.error(
+                    "Found .game_purchase_discount_quantity but regex did not match — "
+                    "Steam may have changed the date format. "
                     "Text: %r | URL: %s",
                     el.text[:200],
                     url,
@@ -301,10 +308,14 @@ class SteamScraper(BaseScraper):
             if result:
                 return result
 
-            logger.warning("Could not find promotion end date on Steam page: %s", url)
+            logger.error(
+                "Could not find promotion end date on Steam page: %s — "
+                "page may use a different layout or the element is JS-rendered.",
+                url,
+            )
             return ""
         except Exception as e:
-            logger.warning("Failed to fetch end date from %s: %s", url, e)
+            logger.error("Failed to fetch end date from %s: %s", url, e)
             return ""
 
     def _fetch_review_score(self, appid: str) -> Optional[str]:


### PR DESCRIPTION
## Summary

- **Status filter tabs** — toggle between "All", "Currently Free" (active promotions), and "Previously Free" (expired); server-side filtering applied before pagination so counts are accurate
- **Store filter pills** — filter by All / Epic / Steam; both filters persist in `sessionStorage` across page refreshes
- **Review scores on cards** — Steam user review labels (blue chip) and Metascore (gold chip) with descriptive emojis
- **Original price** — shown as a strikethrough value on each card
- **Countdown timer** — active promotions show time remaining (days/hours/minutes); highlights "Expires soon!" when under 6 hours
- **Expired card visual** — dimmed opacity, grey CTA button, and small overlay label on the image
- **Contextual empty states** — different icon + message depending on which filter is active
- **README** — updated features list, dashboard section, and roadmap checkboxes

## Test plan

- [x] `pytest tests/` → all 351 tests pass, 1 skipped
- [x] `npm run build` inside `dashboard/` → clean TypeScript + Vite build
- [x] Visit `/dashboard/` — status tabs and store pills visible above toolbar
- [x] "Currently Free" tab → only shows games with `end_date` in the future
- [x] "Previously Free" tab → only shows expired games with correct empty state if none
- [x] Epic / Steam store pills filter correctly; "All" restores full list
- [x] Switching filters resets to page 1; total count updates
- [x] Cards with review scores show blue Steam chip and/or gold Metascore chip
- [x] Cards with `original_price` show strikethrough price row
- [x] Active card shows countdown; games expiring in < 6 hours show "Expires soon!"
- [x] Expired cards are visually dimmed with grey CTA and overlay label
- [ ] Filter state preserved on page refresh (sessionStorage)
- [x] Language switch (EN ↔ ES) updates all filter labels and card text

Closes #71
Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)