### PR TITLE
ci: add ruff lint and dashboard build check to tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ on:
       - QA
 
 jobs:
+  # ─── Python: lint + unit tests ───────────────────────────────────────────────
   test:
     runs-on: ubuntu-latest
     permissions:
@@ -24,6 +25,13 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+
       - name: Install locale
         run: |
           sudo apt-get update -qq
@@ -37,8 +45,38 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
+      - name: Lint (ruff)
+        run: ruff check . --output-format github
+
       - name: Run tests
         run: pytest tests/ -v --tb=short -m "not integration and not production"
         env:
           LANG: es_ES.UTF-8
           LC_ALL: es_ES.UTF-8
+
+  # ─── Dashboard: TypeScript type-check + build ────────────────────────────────
+  dashboard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: dashboard
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (tsc + vite)
+        run: npm run build

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -10,12 +10,13 @@ import sys
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
+
 from alembic import context
 
 # Make the project root importable so we can use config.py
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD  # noqa: E402
+from config import DB_HOST, DB_NAME, DB_PASSWORD, DB_PORT, DB_USER  # noqa: E402
 
 # Alembic Config object, providing access to values from alembic.ini
 alembic_config = context.config

--- a/api.py
+++ b/api.py
@@ -1,9 +1,9 @@
 """REST API for the Free Games Notifier service."""
 
+import logging
 import os
 import threading
 import time
-import logging
 from datetime import datetime, timezone
 from typing import List, Optional
 
@@ -13,17 +13,15 @@ from fastapi.security import APIKeyHeader
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field, field_validator
 
-from modules.notifier import validate_discord_webhook_url
-from modules.models import FreeGame
 from config import (
     API_KEY,
+    DATA_FILE_PATH,
+    DATE_FORMAT,
     DB_HOST,
     DB_NAME,
     DB_PASSWORD,
     DB_PORT,
     DB_USER,
-    DATA_FILE_PATH,
-    DATE_FORMAT,
     ENABLE_HEALTHCHECK,
     ENABLED_STORES,
     EPIC_GAMES_API_URL,
@@ -34,7 +32,8 @@ from config import (
     SCHEDULE_TIME,
     TIMEZONE,
 )
-
+from modules.models import FreeGame
+from modules.notifier import validate_discord_webhook_url
 
 # ---------------------------------------------------------------------------
 # Pydantic response models (for OpenAPI / Swagger documentation)
@@ -376,8 +375,8 @@ def games_history(
 )
 def notify_discord_resend(body: Optional[WebhookOverrideRequest] = None):
     """Re-send the last Discord notification batch to the Discord webhook."""
-    from modules.storage import load_last_notification
     from modules.notifier import send_discord_message
+    from modules.storage import load_last_notification
 
     webhook_url = body.webhook_url if body else None
 
@@ -460,9 +459,9 @@ def check_e2e(body: Optional[WebhookOverrideRequest] = None):
     This endpoint runs the full flow even when the games already exist in the
     database so you can test the pipeline without deleting stored data.
     """
+    from modules.notifier import send_discord_message
     from modules.scrapers import get_enabled_scrapers
     from modules.storage import load_previous_games
-    from modules.notifier import send_discord_message
 
     webhook_url = body.webhook_url if body else None
 

--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+
 from dotenv import load_dotenv
 
 # Load environment variables from .env file

--- a/main.py
+++ b/main.py
@@ -1,38 +1,37 @@
+import logging
+import os
+import threading
+import time
 from datetime import datetime, timedelta, timezone
+from logging.handlers import TimedRotatingFileHandler
 
+import psycopg2
+import pytz
+import requests
+import schedule
+from alembic.config import Config as AlembicConfig
+
+from alembic import command as alembic_command
+from config import (
+    API_HOST,
+    API_PORT,
+    CHECK_INTERVAL_HOURS,
+    DB_HOST,
+    DB_NAME,
+    DB_PASSWORD,
+    DB_PORT,
+    DB_USER,
+    ENABLED_STORES,
+    HEALTHCHECK_INTERVAL,
+    SCHEDULE_TIME,
+    TIMEZONE,
+)
+from modules.database import FreeGamesDatabase
+from modules.healthcheck import healthcheck
 from modules.notifier import send_discord_message
 from modules.scrapers import get_enabled_scrapers
 from modules.storage import load_previous_games, save_games, save_last_notification
-from modules.healthcheck import healthcheck
-from modules.database import FreeGamesDatabase
-from config import (
-    DB_HOST,
-    DB_PORT,
-    DB_NAME,
-    DB_USER,
-    DB_PASSWORD,
-    ENABLED_STORES,
-    CHECK_INTERVAL_HOURS,
-    SCHEDULE_TIME,
-    HEALTHCHECK_INTERVAL,
-    TIMEZONE,
-    API_HOST,
-    API_PORT,
-)
 
-import os
-import schedule
-import time
-import threading
-import requests
-import psycopg2
-
-from alembic.config import Config as AlembicConfig
-from alembic import command as alembic_command
-
-import logging
-from logging.handlers import TimedRotatingFileHandler
-import pytz
 
 # Filter that drops uvicorn access-log entries for the /health endpoint.
 # The health endpoint is polled every minute by the scheduler and would otherwise
@@ -236,7 +235,7 @@ def check_games():
 
     if new_games:
         logging.info(f"Found {len(new_games)} new free games! Sending Discord notification...")
-        
+
         # Wrap Discord send with try-except to prevent scheduler crash
         try:
             send_discord_message(new_games)
@@ -339,6 +338,7 @@ def _verify_required_tables():
 def _start_api_server():
     """Start the FastAPI server in a background daemon thread."""
     import uvicorn
+
     from api import app
 
     # Silence /health access-log noise before uvicorn starts so the filter

--- a/modules/database.py
+++ b/modules/database.py
@@ -1,10 +1,11 @@
 import json
+import logging
+
 import psycopg2
 
-from config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
+from config import DB_HOST, DB_NAME, DB_PASSWORD, DB_PORT, DB_USER
 from modules.models import FreeGame
 
-import logging
 logger = logging.getLogger(__name__)
 
 class FreeGamesDatabase:
@@ -156,7 +157,7 @@ class FreeGamesDatabase:
         except Exception as e:
             logger.error(f"Failed to save games to database: {e}")
             raise
-    
+
     def insert_game(self, game):
         """Insert a game record into the database.
 
@@ -228,7 +229,7 @@ class FreeGamesDatabase:
         try:
             with psycopg2.connect(**self.conn_params) as conn:
                 with conn.cursor() as cursor:
-                    
+
                     # Set schema for this connection
                     cursor.execute("SET search_path to free_games")
 
@@ -239,7 +240,7 @@ class FreeGamesDatabase:
         except Exception as e:
             logger.error(f"Failed to retrieve games: {e}")
             return []
-    
+
     def save_last_notification(self, games):
         """Persist the last-sent notification batch as a JSON blob (single-row upsert)."""
         try:

--- a/modules/healthcheck.py
+++ b/modules/healthcheck.py
@@ -1,7 +1,8 @@
-import requests
-from config import HEALTHCHECK_URL, ENABLE_HEALTHCHECK
-
 import logging
+
+import requests
+
+from config import ENABLE_HEALTHCHECK, HEALTHCHECK_URL
 
 logger = logging.getLogger(__name__)
 

--- a/modules/models.py
+++ b/modules/models.py
@@ -69,4 +69,3 @@ class FreeGame:
             review_scores=review_scores,
             game_type=data.get("game_type", "game"),
         )
- 

--- a/modules/notifier.py
+++ b/modules/notifier.py
@@ -1,13 +1,15 @@
-from config import DISCORD_WEBHOOK_URL, TIMEZONE, LOCALE, DATE_FORMAT, EPIC_GAMES_REGION
-import requests
+import locale
+import logging
 from datetime import datetime
 from typing import Optional
-import pytz
-import locale
 from urllib.parse import urlparse
+
+import pytz
+import requests
+
+from config import DATE_FORMAT, DISCORD_WEBHOOK_URL, EPIC_GAMES_REGION, LOCALE, TIMEZONE
 from modules.retry import with_retry
 
-import logging
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -156,13 +158,13 @@ def _get_safe_webhook_identifier(webhook_url: str) -> str:
 def send_discord_message(new_games, webhook_url: Optional[str] = None):
     """
     Send a Discord webhook message for new free games.
-    
+
     Args:
         new_games: List of game dictionaries to send to Discord
         webhook_url: Optional webhook URL override. Defaults to DISCORD_WEBHOOK_URL.
             Must be a valid Discord webhook URL on either discord.com or discordapp.com
             (e.g. https://discord.com/api/webhooks/... or https://discordapp.com/api/webhooks/...).
-        
+
     Raises:
         ValueError: If webhook URL is not configured or fails validation
         requests.RequestException: If the HTTP request fails
@@ -186,7 +188,7 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
     # Validate user-supplied webhook URLs to prevent SSRF
     if webhook_url is not None:
         validate_discord_webhook_url(effective_webhook_url)
-    
+
     try:
         _STORE_META = {
             "epic": {
@@ -295,10 +297,14 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
                     }
 
                     def _critic_emoji(score_val: int) -> str:
-                        if score_val >= 90:   return "🏆"
-                        if score_val >= 75:   return "⭐"
-                        if score_val >= 61:   return "👍"
-                        if score_val >= 40:   return "⚖️"
+                        if score_val >= 90:
+                            return "🏆"
+                        if score_val >= 75:
+                            return "⭐"
+                        if score_val >= 61:
+                            return "👍"
+                        if score_val >= 40:
+                            return "⚖️"
                         return "👎"
 
                     score_lines = []
@@ -324,7 +330,7 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
             except (AttributeError, ValueError) as e:
                 logger.error(f"Error processing game data for embed: {str(e)} | Game data: {game}")
                 raise
-            
+
         stores_in_batch = {game.store for game in new_games}
         all_dlcs = all(g.game_type == "dlc" for g in new_games)
         if len(stores_in_batch) == 1:
@@ -366,8 +372,8 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
             }
             logger.error(f"Discord API returned non-success status: {error_context}")
             response.raise_for_status()  # Raise exception for bad status codes
-            
-    except requests.exceptions.Timeout as e:
+
+    except requests.exceptions.Timeout:
         safe_webhook_id = _get_safe_webhook_identifier(effective_webhook_url)
         logger.error(
             f"Discord request timed out (10s per-attempt limit, all attempts exhausted) | Webhook identifier: {safe_webhook_id} | Games: {len(new_games)}"
@@ -388,4 +394,4 @@ def send_discord_message(new_games, webhook_url: Optional[str] = None):
     except Exception as e:
         logger.error(f"Unexpected error sending Discord message: {str(e)} | Games: {len(new_games)}")
         raise
-    
+

--- a/modules/retry.py
+++ b/modules/retry.py
@@ -1,5 +1,5 @@
-import time
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 

--- a/modules/scrapers/base.py
+++ b/modules/scrapers/base.py
@@ -1,6 +1,7 @@
 """Base scraper class defining the interface for game scrapers."""
 
 from abc import ABC, abstractmethod
+
 from modules.models import FreeGame
 
 
@@ -16,7 +17,7 @@ class BaseScraper(ABC):
     @abstractmethod
     def fetch_free_games(self) -> list[FreeGame]:
         """Fetch free games from the store.
-        
+
         Returns
         -------
         list[FreeGame]

--- a/modules/scrapers/epic.py
+++ b/modules/scrapers/epic.py
@@ -1,7 +1,9 @@
 """Epic Games Store scraper implementation."""
 
-import requests
 import logging
+
+import requests
+
 from config import EPIC_GAMES_API_URL, EPIC_GAMES_REGION
 from modules.models import FreeGame
 from modules.retry import with_retry

--- a/modules/scrapers/steam.py
+++ b/modules/scrapers/steam.py
@@ -6,6 +6,7 @@ import re
 import time
 from datetime import datetime, timezone
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 import requests
 from bs4 import BeautifulSoup
@@ -15,8 +16,6 @@ from modules.models import FreeGame
 from modules.retry import with_retry
 from modules.scrapers.base import BaseScraper
 from modules.scrapers.review_sources import fetch_metacritic_score
-
-from zoneinfo import ZoneInfo
 
 logger = logging.getLogger(__name__)
 

--- a/modules/storage.py
+++ b/modules/storage.py
@@ -1,6 +1,6 @@
 import json
-import os
 import logging
+import os
 
 from config import DATA_FILE_PATH, DB_HOST, LAST_NOTIFICATION_FILE_PATH
 from modules.models import FreeGame
@@ -227,7 +227,7 @@ def _save_to_file(games):
         raise
     except Exception as e:
         logger.error(f"Unexpected error saving games: {str(e)} | File path: {DATA_FILE_PATH}")
-        raise IOError(f"Unexpected error saving games") from e
+        raise IOError("Unexpected error saving games") from e
 
 
 def _save_last_notification_to_file(games):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest>=7.4
 pytest-mock>=3.10
 httpx>=0.27
 python-dotenv>=1.0
+ruff>=0.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,22 @@
+# Ruff linter configuration
+# Run locally: ruff check .
+# Run with auto-fix: ruff check --fix .
+
+line-length = 120
+
+[lint]
+# E/W = pycodestyle errors/warnings
+# F   = pyflakes (undefined names, unused imports, etc.)
+# I   = isort (import ordering)
+select = ["E", "W", "F", "I"]
+
+ignore = [
+    "E501",  # line too long — enforced by line-length above, but some strings are intentionally long
+]
+
+# Don't lint generated files or local scratch dirs
+exclude = [
+    "alembic/versions/",
+    ".venv/",
+    "dashboard/",
+]

--- a/tests/e2e/test_production_smoke.py
+++ b/tests/e2e/test_production_smoke.py
@@ -1,6 +1,7 @@
-import pytest
-import httpx
 import os
+
+import httpx
+import pytest
 
 API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:8000")
 API_KEY = os.getenv("API_KEY")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,9 @@
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
-from api import app, _metrics, _start_time, increment_metric
+from api import _metrics, app, increment_metric
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -20,7 +20,6 @@ import subprocess
 import pytest
 from dotenv import load_dotenv
 
-
 _COMPOSE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Load environment variables from .env file (same as what compose.yaml uses)
 load_dotenv(dotenv_path=os.path.join(_COMPOSE_DIR, ".env"))

--- a/tests/test_config_region.py
+++ b/tests/test_config_region.py
@@ -1,8 +1,9 @@
 """Tests for the REGION-based config derivation in config.py."""
-import pytest
 from unittest.mock import patch
 
-from config import _region_get, _resolve, _REGION_PROFILES
+import pytest
+
+from config import _REGION_PROFILES, _region_get, _resolve
 
 
 class TestRegionGet:

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,8 +1,9 @@
 """Tests for the database migration runner in main.py."""
 
 import sys
+from unittest.mock import MagicMock, call, patch
+
 import pytest
-from unittest.mock import patch, MagicMock, call
 
 from modules.models import FreeGame
 

--- a/tests/test_multi_store_pipeline.py
+++ b/tests/test_multi_store_pipeline.py
@@ -6,8 +6,7 @@ previously seen games regardless of which store they came from.
 """
 
 import sys
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from modules.models import FreeGame
 

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,10 +1,10 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 import requests as requests_lib
 
 from modules import notifier
 from modules.models import FreeGame
-
 
 VALID_WEBHOOK = "https://discord.com/api/webhooks/123456789/token_abc"
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,11 +1,11 @@
+from unittest.mock import MagicMock, call, patch
+
 import pytest
-from unittest.mock import patch, MagicMock, call
 import requests
 
-from modules.scrapers.epic import EpicGamesScraper
 from modules import notifier
 from modules.retry import with_retry
-
+from modules.scrapers.epic import EpicGamesScraper
 
 # ---------------------------------------------------------------------------
 # Tests for with_retry utility
@@ -105,7 +105,7 @@ class TestFetchFreeGamesRetry:
                 good_response,
             ]
             scraper = EpicGamesScraper()
-            games = scraper.fetch_free_games()
+            scraper.fetch_free_games()
 
         assert mock_get.call_count == 2
 

--- a/tests/test_scrapper.py
+++ b/tests/test_scrapper.py
@@ -1,11 +1,11 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
-from modules.scrapers.epic import EpicGamesScraper
-from modules.scrapers.review_sources import make_metacritic_slug, fetch_metacritic_score
-from modules.models import FreeGame
 from config import EPIC_GAMES_REGION
-
+from modules.models import FreeGame
+from modules.scrapers.epic import EpicGamesScraper
+from modules.scrapers.review_sources import fetch_metacritic_score, make_metacritic_slug
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_steam_scrapper.py
+++ b/tests/test_steam_scrapper.py
@@ -1,7 +1,8 @@
-import pytest
-from unittest.mock import patch, MagicMock
-from datetime import datetime as _real_datetime, timezone as _utc_tz
+from datetime import datetime as _real_datetime
+from datetime import timezone as _utc_tz
+from unittest.mock import MagicMock, patch
 
+import pytest
 import requests as req
 
 from modules.scrapers.steam import SteamScraper, _parse_steam_end_date

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,12 +1,12 @@
 import json
 import os
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 from modules import storage
 from modules.database import FreeGamesDatabase
 from modules.models import FreeGame
-
 
 # ---------------------------------------------------------------------------
 # Tests for load_previous_games
@@ -118,7 +118,6 @@ class TestSaveGames:
 
     def test_raises_type_error_on_unserializable_data(self, tmp_path):
         from unittest.mock import patch as _patch
-        from modules.models import FreeGame
         path = str(tmp_path / "games.json")
         game = FreeGame(
             title="Test", store="epic", url="https://example.com", image_url="",


### PR DESCRIPTION
## Summary

- **New `dashboard` job** (runs in parallel with `test`) — `npm ci` + `npm run build` (`tsc && vite build`). Catches TypeScript type errors and broken imports on every PR; this would have caught the `expiredBadge` interface mismatch earlier this session before it reached review.
- **Ruff lint step** added to the `test` job before pytest — fails fast on real code issues; uses `--output-format github` for inline PR annotations on the diff.
- **pip and npm caching** added to both jobs to reduce build times.
- **`ruff.toml`** added with project-wide config (E/W/F/I rules, 120-char line length, excludes `alembic/versions/` and `dashboard/`).
- **`ruff>=0.4`** added to `requirements-dev.txt` so developers get the same version locally.
- Fixed all 56 pre-existing ruff violations across the codebase: import ordering, trailing whitespace on blank lines, unused imports/variables, f-string without placeholders, and inline `if: return` statements expanded to multi-line.

## Test plan

- [x] PR triggers CI — both `test` and `dashboard` jobs appear in the checks
- [x] `dashboard` job passes: `npm ci` + `npm run build` succeed
- [ ] `test` job passes: `ruff check .` reports no violations, then `pytest` passes
- [ ] Introduce a TypeScript type error locally → `npm run build` fails in CI
- [ ] Introduce an unused import locally → `ruff check .` fails in CI
- [ ] `ruff check .` passes locally with `pip install -r requirements-dev.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)