### PR TITLE
ci: trigger n8n deploy webhook after successful image push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,10 @@ jobs:
         if: ${{ !contains(github.ref_name, '-') && secrets.N8N_WEBHOOK_URL != '' }}
         env:
           N8N_URL: ${{ secrets.N8N_WEBHOOK_URL }}
+          N8N_SECRET: ${{ secrets.N8N_WEBHOOK_SECRET }}
           VERSION: ${{ github.ref_name }}
         run: |
           curl -f --max-time 30 -X POST "$N8N_URL" \
             -H "Content-Type: application/json" \
+            -H "X-Webhook-Secret: $N8N_SECRET" \
             -d "{\"repo\":\"free-games-notifier\",\"version\":\"${VERSION}\",\"status\":\"deployed\"}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,10 @@ jobs:
           subject-name: ghcr.io/juliomoralesb/free-games-notifier
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+      - name: Trigger deploy via n8n
+        if: ${{ !contains(github.ref_name, '-') }}
+        run: |
+          curl -f --max-time 30 -X POST "${{ secrets.N8N_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{"repo":"free-games-notifier","version":"${{ github.ref_name }}","status":"deployed"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           push-to-registry: true
 
       - name: Trigger deploy via n8n
-        if: ${{ !contains(github.ref_name, '-') && secrets.N8N_WEBHOOK_URL != '' }}
+        if: ${{ !contains(github.ref_name, '-') && secrets.N8N_WEBHOOK_URL != '' && secrets.N8N_WEBHOOK_SECRET != '' }}
         env:
           N8N_URL: ${{ secrets.N8N_WEBHOOK_URL }}
           N8N_SECRET: ${{ secrets.N8N_WEBHOOK_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,11 @@ jobs:
           push-to-registry: true
 
       - name: Trigger deploy via n8n
-        if: ${{ !contains(github.ref_name, '-') }}
+        if: ${{ !contains(github.ref_name, '-') && secrets.N8N_WEBHOOK_URL != '' }}
+        env:
+          N8N_URL: ${{ secrets.N8N_WEBHOOK_URL }}
+          VERSION: ${{ github.ref_name }}
         run: |
-          curl -f --max-time 30 -X POST "${{ secrets.N8N_WEBHOOK_URL }}" \
+          curl -f --max-time 30 -X POST "$N8N_URL" \
             -H "Content-Type: application/json" \
-            -d '{"repo":"free-games-notifier","version":"${{ github.ref_name }}","status":"deployed"}'
+            -d "{\"repo\":\"free-games-notifier\",\"version\":\"${VERSION}\",\"status\":\"deployed\"}"


### PR DESCRIPTION
## Summary

- Adds a **Trigger deploy via n8n** step at the end of the `release` job in `.github/workflows/release.yml`
- Calls `N8N_WEBHOOK_URL` (repository secret) with a JSON payload: `{"repo", "version", "status":"deployed"}`
- Step is skipped for pre-releases (tags containing `-`) — consistent with the `:latest` tag guard already in place
- `curl -f` ensures HTTP 4xx/5xx responses fail the step; `--max-time 30` prevents hangs

## Prerequisites

`N8N_WEBHOOK_URL` must be added as a repository secret in **GitHub Settings → Secrets and variables → Actions**.

## Test plan

- [ ] Add `N8N_WEBHOOK_URL` secret to the repository
- [ ] Tag a stable release (`vX.Y.Z`, no pre-release suffix) and verify the step runs and n8n triggers a Portainer redeploy + Telegram notification
- [ ] Tag a pre-release (`vX.Y.Z-rc.1`) and verify the step is **skipped**
- [ ] Temporarily use an invalid URL to verify `curl -f` causes the step to fail the job

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)