### PR TITLE
fix: resolve release workflow parse error (secrets in if:)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,12 +61,16 @@ jobs:
           push-to-registry: true
 
       - name: Trigger deploy via n8n
-        if: ${{ !contains(github.ref_name, '-') && secrets.N8N_WEBHOOK_URL != '' && secrets.N8N_WEBHOOK_SECRET != '' }}
+        if: ${{ !contains(github.ref_name, '-') }}
         env:
           N8N_URL: ${{ secrets.N8N_WEBHOOK_URL }}
           N8N_SECRET: ${{ secrets.N8N_WEBHOOK_SECRET }}
           VERSION: ${{ github.ref_name }}
         run: |
+          if [ -z "$N8N_URL" ] || [ -z "$N8N_SECRET" ]; then
+            echo "Skipping deploy: N8N_WEBHOOK_URL or N8N_WEBHOOK_SECRET not configured"
+            exit 0
+          fi
           curl -f --max-time 30 -X POST "$N8N_URL" \
             -H "Content-Type: application/json" \
             -H "X-Webhook-Secret: $N8N_SECRET" \


### PR DESCRIPTION
## Summary

- The release workflow was failing to parse because `secrets` context is not available in step-level `if:` conditionals in GitHub Actions
- This caused every push to any branch to show as a workflow failure, and the tag `v1.0.0-rc.1` never triggered the release job
- Fix: remove `secrets.*` from the `if:` condition and check for empty env vars inside the `run:` script with an early `exit 0`

## Test plan

- [ ] Workflow parses correctly (no more "workflow file issue" on branch pushes)
- [ ] Tag push triggers the release job end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)