### PR TITLE
Fix workflow parse error by moving secret checks to script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,12 +61,16 @@ jobs:
           push-to-registry: true
 
       - name: Trigger deploy via n8n
-        if: ${{ !contains(github.ref_name, '-') && secrets.N8N_WEBHOOK_URL != '' && secrets.N8N_WEBHOOK_SECRET != '' }}
+        if: ${{ !contains(github.ref_name, '-') }}
         env:
           N8N_URL: ${{ secrets.N8N_WEBHOOK_URL }}
           N8N_SECRET: ${{ secrets.N8N_WEBHOOK_SECRET }}
           VERSION: ${{ github.ref_name }}
         run: |
+          if [ -z "$N8N_URL" ] || [ -z "$N8N_SECRET" ]; then
+            echo "Skipping deploy: N8N_WEBHOOK_URL or N8N_WEBHOOK_SECRET not configured"
+            exit 0
+          fi
           curl -f --max-time 30 -X POST "$N8N_URL" \
             -H "Content-Type: application/json" \
             -H "X-Webhook-Secret: $N8N_SECRET" \


### PR DESCRIPTION
This pull request updates the deployment workflow to improve the handling of missing n8n webhook secrets. The workflow step that triggers a deploy via n8n will now always run, but will explicitly check for required secrets and skip the deploy with a clear message if they are not configured.

**Workflow improvements:**

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L64-R73): Changed the `if` condition for the deploy step to always run, and added a shell check to skip deployment with a message if `N8N_WEBHOOK_URL` or `N8N_WEBHOOK_SECRET` are not set. This makes the workflow more robust and easier to debug when secrets are missing.