### PR TITLE
Remove n8n deploy webhook step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,19 +59,3 @@ jobs:
           subject-name: ghcr.io/juliomoralesb/free-games-notifier
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
-
-      - name: Trigger deploy via n8n
-        if: ${{ !contains(github.ref_name, '-') }}
-        env:
-          N8N_URL: ${{ secrets.N8N_WEBHOOK_URL }}
-          N8N_SECRET: ${{ secrets.N8N_WEBHOOK_SECRET }}
-          VERSION: ${{ github.ref_name }}
-        run: |
-          if [ -z "$N8N_URL" ] || [ -z "$N8N_SECRET" ]; then
-            echo "Skipping deploy: N8N_WEBHOOK_URL or N8N_WEBHOOK_SECRET not configured"
-            exit 0
-          fi
-          curl -f --max-time 30 -X POST "$N8N_URL" \
-            -H "Content-Type: application/json" \
-            -H "X-Webhook-Secret: $N8N_SECRET" \
-            -d "{\"repo\":\"free-games-notifier\",\"version\":\"${VERSION}\",\"status\":\"deployed\"}"


### PR DESCRIPTION
This pull request makes a small change to the release workflow by removing the step that triggered a deployment via n8n after a successful build.

- Removed deployment trigger:
  * The step named "Trigger deploy via n8n" was deleted from the `.github/workflows/release.yml` file, so deployments will no longer be triggered through the n8n webhook as part of the release process.