### PR TITLE
feat: structured JSON logging for Loki/Grafana

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ import time
 from datetime import datetime, timedelta, timezone
 
 import psycopg2
-import pytz
 import requests
 import schedule
 from alembic.config import Config as AlembicConfig

--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ import os
 import threading
 import time
 from datetime import datetime, timedelta, timezone
-from logging.handlers import TimedRotatingFileHandler
 
 import psycopg2
 import pytz
@@ -28,9 +27,12 @@ from config import (
 )
 from modules.database import FreeGamesDatabase
 from modules.healthcheck import healthcheck
+from modules.logging_config import setup_logging
 from modules.notifier import send_discord_message
 from modules.scrapers import get_enabled_scrapers
 from modules.storage import load_previous_games, save_games, save_last_notification
+
+setup_logging(timezone=TIMEZONE, log_file="/mnt/logs/notifier.log")
 
 
 # Filter that drops uvicorn access-log entries for the /health endpoint.
@@ -41,36 +43,6 @@ class _HealthEndpointFilter(logging.Filter):
         # uvicorn formats access entries as: '<ip> - "GET /health HTTP/1.1" <status>'
         # Match on ' /health ' (space + path + space) to cover any HTTP method.
         return ' /health ' not in record.getMessage()
-
-
-# Custom formatter to display log timestamps in the configured timezone instead of UTC
-class TimezoneFormatter(logging.Formatter):
-    def __init__(self, fmt, tz):
-        super().__init__(fmt)
-        try:
-            self.tz = pytz.timezone(tz)
-        except pytz.exceptions.UnknownTimeZoneError:
-            logging.warning(
-                "Timezone %s is not available, falling back to UTC. "
-                "Log timestamps will be in UTC. "
-                "Check the TIMEZONE environment variable.",
-                tz,
-            )
-            self.tz = pytz.utc
-
-    def converter(self, timestamp):
-        return datetime.fromtimestamp(timestamp, tz=pytz.utc).astimezone(self.tz).timetuple()
-
-# Configure logging to write to a file and rotate weekly
-log_handler = TimedRotatingFileHandler("/mnt/logs/notifier.log", when="W1", interval=1, backupCount=4)
-log_handler.setLevel(logging.INFO)
-log_handler.setFormatter(TimezoneFormatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s', tz=TIMEZONE))
-
-console_handler = logging.StreamHandler()
-console_handler.setLevel(logging.INFO)
-console_handler.setFormatter(TimezoneFormatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s', tz=TIMEZONE))
-
-logging.basicConfig(level=logging.INFO, handlers=[log_handler, console_handler])
 
 
 def _is_still_active(game) -> bool:

--- a/modules/logging_config.py
+++ b/modules/logging_config.py
@@ -1,0 +1,95 @@
+"""
+Structured JSON logging configuration for Free Games Notifier.
+
+All log entries are emitted as single-line JSON objects with consistent fields:
+  - timestamp  : ISO 8601 with timezone offset (e.g. "2026-04-28T10:00:00-06:00")
+  - level      : log level string (INFO, WARNING, ERROR, DEBUG)
+  - logger     : logger name (e.g. "modules.notifier", "__main__")
+  - message    : the log message
+  - service    : always "free-games-notifier" — useful as a Loki label
+
+Promtail pipeline_stages example:
+  - json:
+      expressions:
+        level: level
+        message: message
+        service: service
+  - labels:
+      level:
+      service:
+"""
+
+import logging
+import logging.handlers
+from datetime import datetime
+
+import pytz
+try:
+    from pythonjsonlogger.json import JsonFormatter as _JsonFormatterBase  # v3+
+except ImportError:
+    from pythonjsonlogger.jsonlogger import JsonFormatter as _JsonFormatterBase  # v2
+
+SERVICE_NAME = "free-games-notifier"
+
+
+class _JsonFormatter(_JsonFormatterBase):
+    """JsonFormatter that adds standard fields and a timezone-aware timestamp."""
+
+    def __init__(self, *args, tz: str = "UTC", **kwargs):
+        super().__init__(*args, **kwargs)
+        try:
+            self._tz = pytz.timezone(tz)
+        except pytz.exceptions.UnknownTimeZoneError:
+            logging.getLogger(__name__).warning(
+                "Unknown timezone %r for log formatter — falling back to UTC.", tz
+            )
+            self._tz = pytz.utc
+
+    def add_fields(self, log_record: dict, record: logging.LogRecord, message_dict: dict):
+        super().add_fields(log_record, record, message_dict)
+
+        # Timezone-aware ISO 8601 timestamp
+        log_record["timestamp"] = (
+            datetime.fromtimestamp(record.created, tz=pytz.utc)
+            .astimezone(self._tz)
+            .isoformat()
+        )
+        log_record["level"] = record.levelname
+        log_record["logger"] = record.name
+        log_record["service"] = SERVICE_NAME
+
+        # Remove redundant / noisy fields added by the base formatter
+        for key in ("asctime", "name", "levelname"):
+            log_record.pop(key, None)
+
+
+def setup_logging(timezone: str = "UTC", log_file: str = "/mnt/logs/notifier.log") -> None:
+    """
+    Configure JSON structured logging for the application.
+
+    Should be called once at startup before any loggers are used.
+    Both the rotating file and stdout receive the same JSON format.
+
+    Args:
+        timezone: IANA timezone string for log timestamps (e.g. "America/Mexico_City").
+        log_file: Absolute path to the rotating log file.
+    """
+    formatter = _JsonFormatter(fmt="%(message)s", tz=timezone)
+
+    file_handler = logging.handlers.TimedRotatingFileHandler(
+        log_file, when="W1", interval=1, backupCount=4
+    )
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(formatter)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO)
+    console_handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    # Only add handlers if none are configured yet (same behaviour as basicConfig without force).
+    # This prevents overriding pytest's log capture during test runs.
+    if not root.handlers:
+        root.addHandler(file_handler)
+        root.addHandler(console_handler)

--- a/modules/logging_config.py
+++ b/modules/logging_config.py
@@ -24,6 +24,7 @@ import logging.handlers
 from datetime import datetime
 
 import pytz
+
 try:
     from pythonjsonlogger.json import JsonFormatter as _JsonFormatterBase  # v3+
 except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alembic==1.16.5
+python-json-logger>=2.0
 beautifulsoup4==4.13.3
 certifi==2025.1.31
 charset-normalizer==3.4.1


### PR DESCRIPTION
## Summary

- Replaces plain-text log format (`asctime - name - levelname - message`) with single-line JSON objects
- Each log entry includes: `timestamp` (ISO 8601 + timezone), `level`, `logger`, `message`, `service: "free-games-notifier"`
- Promtail's existing pipeline already handles JSON + plain-text mixed — no Promtail config change required for `level` extraction
- Compatible with `python-json-logger` v2 and v3

## Example output

```json
{"message": "Found 2 new free games", "timestamp": "2026-04-28T10:00:00-06:00", "level": "INFO", "logger": "__main__", "service": "free-games-notifier"}
{"message": "Failed to fetch from Steam scraper", "timestamp": "2026-04-28T10:00:01-06:00", "level": "ERROR", "logger": "modules.scrapers.steam", "service": "free-games-notifier"}
```

## Optional Promtail improvement (cosmetic)

To show clean `message` text in Grafana instead of the full JSON blob, add a scoped stage:

```yaml
- match:
    selector: '{container="free-games-notifier"}'
    stages:
      - json:
          expressions:
            message: message
      - output:
          source: message
```

## Test plan

- [ ] Container logs show JSON format on startup
- [ ] `level` label appears correctly in Grafana Logs Drilldown
- [ ] Existing services unaffected (Promtail pipeline handles mixed formats)

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)