### PR TITLE
docs: split README into focused docs (self-hosting, config, api, …)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,344 +1,65 @@
 # Free Games Notifier
 
-A Python-based scheduler that monitors the Epic Games Store and Steam for free game promotions and sends Discord notifications. Runs as a Docker container with health check support, optional PostgreSQL integration, a REST API, and a built-in web dashboard.
-
-## Features
-
-- ✅ **Multi-Store Monitoring**: Checks Epic Games Store and Steam for free games — on a daily schedule or a configurable repeating interval
-- 💬 **Discord Notifications**: Sends beautifully formatted Discord embeds with game details, original price, and review scores (Steam user reviews + Metacritic)
-- 📊 **Persistent Storage**: Maintains game history — PostgreSQL when `DB_HOST` is set, JSON file otherwise
-- 🏥 **Health Checks**: Optional UptimeKuma/Healthchecks.io integration for monitoring
-- 🌐 **Web Dashboard**: Browse, filter, and search the full history of tracked free games at `/dashboard/`
-- 🔌 **REST API**: Built-in FastAPI endpoints for health, history, metrics, and notification management
-- 🐳 **Docker Ready**: Includes Docker and docker-compose configurations
-- 🌍 **Fully Configurable**: Set `REGION` to a single IANA timezone string and get timezone, locale, Steam language, and Steam country all at once — or configure each variable individually
-
-## Prerequisites
-
-### Local Development
-- Python 3.9+
-- pip (Python package manager)
-- Virtual environment support (venv)
-- Node.js 20+ and npm (only required to build the dashboard locally)
-
-### Docker Deployment
-- Docker 20.10+
-- Docker Compose v2+ (`docker compose`) or Compose v1 (`docker-compose`)
-- (Optional) PostgreSQL 13+ for database-backed storage
-
-## Local Setup
-
-### 1. Clone the Repository
-
-```bash
-git clone https://github.com/JulioMoralesB/free-games-notifier.git
-cd free-games-notifier
-```
-
-### 2. Create a Virtual Environment
-
-```bash
-python3 -m venv env
-source env/bin/activate  # On Windows: env\Scripts\activate
-```
-
-### 3. Install Dependencies
-
-```bash
-pip install -r requirements.txt
-```
-
-### 4. Configure Environment Variables
-
-Create a `.env` file in the root directory (see [Environment Variables Reference](#environment-variables-reference) for all options):
-
-```env
-# Required
-DISCORD_WEBHOOK_URL=https://discordapp.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_TOKEN
-
-# Optional: PostgreSQL (file-based JSON by default)
-DB_HOST=localhost
-DB_PORT=5432
-DB_NAME=free_games
-DB_USER=postgres
-DB_PASSWORD=your_password
-
-# Optional: Unified region (derives timezone, locale, Steam language & country automatically)
-REGION=America/New_York
-
-# Optional: Scheduler
-SCHEDULE_TIME=12:00
-```
-
-> To get your Discord webhook URL, go to **Server Settings → Integrations → Webhooks** and create a new webhook for the desired channel.
-
-### 5. Run the Scheduler
-
-```bash
-python main.py
-```
-
-The service checks for new free games daily at `SCHEDULE_TIME` and logs activity to `/mnt/logs/notifier.log`.
-In Docker deployments, this log path is typically backed by a bind-mounted host directory so logs persist outside the container.
-
-## Storage Backends
-
-The notifier automatically selects a storage backend based on the `DB_HOST` environment variable:
-
-| `DB_HOST` set? | Backend used | Data location |
-|---|---|---|
-| ✅ Yes | PostgreSQL (`free_games` schema) | Remote database |
-| ❌ No (default) | JSON file | `/mnt/data/free_games.json` |
-
-> The application stores JSON-backed data under `/mnt/data/free_games.json`. In Docker deployments, `/mnt/data` is typically the container path you bind-mount to a host directory or volume for persistence.
-When `DB_HOST` is configured the application creates the schema and applies any pending Alembic migrations automatically on startup. The database derives `game_id` from the game `link` and uses `ON CONFLICT (game_id) DO UPDATE` to upsert existing rows, refreshing fields such as `promotion_end_date`.
-
-## Database Migrations
-
-Schema changes are managed by [Alembic](https://alembic.sqlalchemy.org/) and applied **automatically on startup**. Migration scripts live in `alembic/versions/`.
-
-| Revision | Description |
-|----------|-------------|
-| `0001`   | Initial schema — creates the `free_games` schema and `games` table |
-| `0002`   | Widens `games.game_id` from `VARCHAR(255)` to `TEXT` |
-| `0003`   | Converts `games.promotion_end_date` from `TIMESTAMP` to `TEXT` (ISO-8601 UTC) |
-| `0004`   | Adds `last_notification` table for Discord resend support |
-
-For manual migration commands and instructions for creating new migrations, see [docs/database-migrations.md](docs/database-migrations.md).
-
-## REST API
-
-The service exposes a FastAPI REST API on `API_HOST:API_PORT` (default `0.0.0.0:8000`). Interactive docs are available at `/docs`.
-
-| Endpoint | Method | Auth | Description |
-|---|---|---|---|
-| `/health` | GET | — | Epic Games API and database health check |
-| `/games/latest` | GET | — | Most recently fetched free games |
-| `/games/history` | GET | — | Paginated full game history (`limit`, `offset` query params) |
-| `/notify/discord/resend` | POST | API key | Re-send last Discord notification |
-| `/metrics` | GET | — | Uptime, games processed, notification counts |
-| `/config` | GET | API key | Non-secret runtime configuration |
-| `/check` | POST | API key | Full end-to-end pipeline test |
-| `/dashboard/` | GET | — | Web dashboard (served as static files) |
-
-Protected endpoints (`POST` methods and `GET /config`) require an `X-API-Key` header when `API_KEY` is set.
-
-| Variable | Default | Description |
-|---|---|---|
-| `API_HOST` | `0.0.0.0` | Interface to bind the API server |
-| `API_PORT` | `8000` | Port to listen on |
-| `API_KEY` | _(empty)_ | Secret key for mutating endpoints and `GET /config`; leave empty to disable auth |
-
-## Web Dashboard
-
-The dashboard is a React/TypeScript SPA served at **`http://<host>:<API_PORT>/dashboard/`** — no additional container or CORS configuration needed.
+A Python-based scheduler that monitors the Epic Games Store and Steam for free game promotions and sends Discord notifications. Ships as a Docker image with optional PostgreSQL storage, a REST API, and a built-in web dashboard.
 
 ![Web Dashboard](https://github.com/user-attachments/assets/1ffef230-45e2-4ef1-9ffb-6a7a9d573d62)
 
-- Game cards with thumbnail, title, description, original price, review scores, and promotion end date
-- **Status filter**: tabs to view "Currently Free", "Previously Free", or all games
-- **Store filter**: pill buttons to filter by All / Epic Games / Steam
-- Countdown timer on active promotions; expired cards are visually dimmed
-- Live search by title or description (client-side, within the current page)
-- Sort by date or title
-- Server-side pagination with smart ellipsis (filters applied before paginating)
-- Responsive dark theme, no external UI framework
-- English and Spanish built-in; browser language auto-detected; preference persisted in `localStorage`
-- Filter selections (status, store) persisted in `sessionStorage`
+## Features
 
-For development setup, hot-reload, and adding new languages, see [docs/dashboard.md](docs/dashboard.md).
+- 🎮 **Multi-store monitoring** — Epic Games Store and Steam, on a daily schedule or every N hours
+- 💬 **Rich Discord notifications** — embeds with title, description, original price, review scores, and DLC indicator
+- 📊 **Web dashboard** — browse, filter, and search the full free-games history at `/dashboard/`
+- 🔌 **REST API** — health, history, metrics, and notification management endpoints
+- 🌍 **Region-aware** — one `REGION` variable derives timezone, locale, Steam language, and country
+- 📦 **Pluggable storage** — PostgreSQL when `DB_HOST` is set, JSON file otherwise
+- 🐳 **Docker-first** — pre-built multi-arch image on `ghcr.io`
 
-## Self-hosting
-
-The easiest way to run Free Games Notifier on your own server is with the pre-built Docker image published on [GitHub Container Registry](https://github.com/JulioMoralesB/free-games-notifier/pkgs/container/free-games-notifier). No build step required.
-
-### Prerequisites
-
-- Docker 20.10+
-- Docker Compose v2 (`docker compose`) or Compose v1 (`docker-compose`)
-- A Discord webhook URL — create one via **Server Settings → Integrations → Webhooks**
-- (Optional) PostgreSQL 13+ for database-backed storage; JSON file storage is used otherwise
-
-### Quick Start
-
-**1. Get the files**
+## Quick Start
 
 ```bash
 git clone https://github.com/JulioMoralesB/free-games-notifier.git
 cd free-games-notifier
-```
-
-**2. Configure environment variables**
-
-```bash
 cp .env.example .env
-```
-
-Open `.env` and set at minimum:
-
-```env
-DISCORD_WEBHOOK_URL=https://discordapp.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_TOKEN
-```
-
-The file already includes sensible defaults for `DATA_PATH` (`./data`) and `LOGS_PATH` (`./logs`), which are the host directories Docker will bind-mount for persistent storage and logs. Change them to absolute paths if you prefer a specific location.
-
-Optionally set `REGION` to your IANA timezone string (e.g. `America/Mexico_City`) — this derives timezone, locale, Steam language, and country in one step. See the [Environment Variables Reference](#environment-variables-reference) for all options.
-
-To enable PostgreSQL, uncomment and fill in the `DB_*` variables; otherwise the service uses JSON file storage automatically.
-
-**3. Start the service**
-
-```bash
-docker compose pull   # pull the pre-built image from ghcr.io
-docker compose up -d
-```
-
-Docker Compose creates the `data/` and `logs/` directories and the internal network automatically on first run. The service applies any pending database migrations and begins the scheduling loop. Dashboard and API are available at `http://localhost:8000`.
-
-> **Building from source:** If you prefer to build the image locally (e.g. for development or testing local changes), skip `docker compose pull` and run `docker compose up -d --build` instead.
-
-### Database migrations
-
-When `DB_HOST` is configured, Alembic migrations run **automatically on startup** — no manual step is needed. Migration log lines on first boot are expected. For manual migration commands see [docs/database-migrations.md](docs/database-migrations.md).
-
-### Pinning to a specific version
-
-`compose.yaml` uses `:latest` by default. For reproducible deployments, pin to a specific semver tag:
-
-```yaml
-# compose.yaml
-image: ghcr.io/juliomoralesb/free-games-notifier:1.2.3
-```
-
-Available versions are listed on the [packages page](https://github.com/JulioMoralesB/free-games-notifier/pkgs/container/free-games-notifier).
-
-### Updating
-
-```bash
+# Edit .env and set DISCORD_WEBHOOK_URL (minimum required)
 docker compose pull
 docker compose up -d
 ```
 
-This pulls the latest image and restarts the service. Any new migrations run automatically on startup.
+Dashboard and API are available at `http://localhost:8000`.
 
-### Using only Docker (no Compose)
+For a step-by-step walkthrough, optional PostgreSQL setup, version pinning, and update instructions, see the [Self-hosting Guide](docs/self-hosting.md).
 
-```bash
-docker run -d \
-  --name free-games-notifier \
-  -e DISCORD_WEBHOOK_URL="YOUR_WEBHOOK_URL" \
-  -e REGION=America/New_York \
-  -v /your/data/path:/mnt/data \
-  -v /your/logs/path:/mnt/logs \
-  -p 8000:8000 \
-  ghcr.io/juliomoralesb/free-games-notifier:latest
-```
+## Documentation
 
-## Environment Variables Reference
-
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `DISCORD_WEBHOOK_URL` | ✅ Yes | — | Discord webhook URL for sending notifications |
-| `ENABLED_STORES` | ❌ No | `epic` | Comma-separated list of stores to scrape. Supported: `epic`, `steam` (e.g. `epic,steam`) |
-| `EPIC_GAMES_API_URL` | ❌ No | Official API | Epic Games Store API endpoint override |
-| `HEALTHCHECK_URL` | ❌ No | — | Healthchecks.io or UptimeKuma ping URL |
-| `ENABLE_HEALTHCHECK` | ❌ No | `false` | Enable health check pings (`true`/`false`) |
-| `DB_HOST` | ❌ No | — | PostgreSQL host (leave empty to use file storage) |
-| `DB_PORT` | ❌ No | `5432` | PostgreSQL port |
-| `DB_NAME` | ❌ No | — | PostgreSQL database name |
-| `DB_USER` | ❌ No | — | PostgreSQL username |
-| `DB_PASSWORD` | ❌ No | — | PostgreSQL password |
-| `REGION` | ❌ No | — | **Recommended.** IANA timezone string (e.g. `America/Mexico_City`). Automatically derives `TIMEZONE`, `LOCALE`, `EPIC_GAMES_REGION`, `STEAM_LANGUAGE`, and `STEAM_COUNTRY`. Individual vars below take precedence when also set. Supported values listed in `.env.example`. |
-| `TIMEZONE` | ❌ No | `UTC` (or `REGION`) | IANA timezone for date display in notifications (e.g. `America/New_York`, `Europe/London`) |
-| `LOCALE` | ❌ No | `en_US.UTF-8` (or `REGION`) | Locale for date formatting (e.g. `es_MX.UTF-8`, `de_DE.UTF-8`). All locales supported by the built-in region profiles are pre-installed in the Docker image. |
-| `EPIC_GAMES_REGION` | ❌ No | `en-US` (or `REGION`) | Region code for Epic Games Store links (e.g. `es-MX`, `de-DE`) |
-| `STEAM_LANGUAGE` | ❌ No | `english` (or `REGION`) | Language for Steam game descriptions (e.g. `spanish`, `french`). Full list: [Steam localization languages](https://partner.steamgames.com/doc/store/localization/languages) |
-| `STEAM_COUNTRY` | ❌ No | `US` (or `REGION`) | ISO 3166-1 alpha-2 country code for Steam store requests — controls price currency (e.g. `MX` → MXN, `DE` → EUR, `GB` → GBP) |
-| `STEAM_REQUEST_DELAY_MS` | ❌ No | `1500` | Milliseconds to wait between Steam HTTP requests to avoid rate limiting |
-| `CHECK_INTERVAL_HOURS` | ❌ No | — | Run on a repeating interval (e.g. `6` = every 6 hours) instead of once daily. Minimum: `1`. Recommended when Steam is enabled. Leave empty to use `SCHEDULE_TIME`. |
-| `SCHEDULE_TIME` | ❌ No | `12:00` | Daily check time in `HH:MM`, interpreted in `TIMEZONE`. Used only when `CHECK_INTERVAL_HOURS` is not set. |
-| `HEALTHCHECK_INTERVAL` | ❌ No | `1` | Health check ping interval in minutes |
-| `DATE_FORMAT` | ❌ No | `%B %d, %Y at %I:%M %p` | strftime format for the promotion end date in Discord notifications |
-| `API_HOST` | ❌ No | `0.0.0.0` | Interface the REST API and dashboard server binds to |
-| `API_PORT` | ❌ No | `8000` | Port the REST API and dashboard server listens on |
-| `API_KEY` | ❌ No | _(empty)_ | Secret key for mutating API endpoints; leave empty to disable auth |
-
-### Steam notes
-
-- Free game promotions on Steam are infrequent. When only Steam is enabled (or when Steam returns no results), the scheduler will log "No free games found" more often than with Epic — this is expected.
-- Steam requests are throttled by `STEAM_REQUEST_DELAY_MS` (default 1 500 ms) to avoid hitting rate limits. Lowering this value may cause HTTP 429 errors; raising it is safe.
-- Set `CHECK_INTERVAL_HOURS` when Steam is enabled — Steam free games can appear at any time of day, unlike the predictable Epic Thursday rotation.
-
-## Project Structure
-
-```
-.
-├── main.py                 # Main scheduler entry point
-├── api.py                  # FastAPI REST API + dashboard static file mount
-├── config.py               # Configuration and environment variables
-├── requirements.txt        # Python dependencies
-├── alembic.ini             # Alembic migration tool configuration
-├── Dockerfile              # Multi-stage Docker image (Node.js builder + Python runtime)
-├── compose.yaml            # Docker Compose orchestration
-├── dashboard/              # React/TypeScript web dashboard (Vite)
-├── alembic/versions/       # Versioned migration scripts
-├── modules/
-│   ├── scrapers/           # Store scraper implementations (Epic, Steam, …)
-│   ├── notifier.py         # Discord webhook sender
-│   ├── storage.py          # Storage dispatcher (PostgreSQL or JSON file)
-│   ├── database.py         # PostgreSQL database operations
-│   ├── models.py           # Shared FreeGame dataclass
-│   └── healthcheck.py      # Health check monitoring
-└── data/
-    ├── free_games.json     # Local game history (file-based storage only)
-    └── logs/               # Application logs
-```
-
-## Testing
-
-```bash
-pip install -r requirements-dev.txt
-pytest tests/ -v
-```
-
-Tests cover both the file-backend and PostgreSQL-backend paths. File-backend tests explicitly set `DB_HOST=None` to remain hermetic.
-
-## Troubleshooting
-
-See [docs/troubleshooting.md](docs/troubleshooting.md) for common issues and solutions.
-
-Logs are written to `/mnt/logs/notifier.log` and rotated weekly:
-
-```bash
-tail -f /mnt/logs/notifier.log
-```
-
-## License
-
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
-
-## Support
-
-- 🐛 [Report Issues](https://github.com/JulioMoralesB/Free-Games-Notifier/issues)
+| Topic | Doc |
+|---|---|
+| Self-hosting with Docker | [docs/self-hosting.md](docs/self-hosting.md) |
+| All environment variables | [docs/configuration.md](docs/configuration.md) |
+| REST API reference | [docs/api.md](docs/api.md) |
+| Storage backends (PostgreSQL vs JSON) | [docs/storage-backends.md](docs/storage-backends.md) |
+| Database migrations | [docs/database-migrations.md](docs/database-migrations.md) |
+| Local development from source | [docs/local-development.md](docs/local-development.md) |
+| Project architecture | [docs/architecture.md](docs/architecture.md) |
+| Dashboard development | [docs/dashboard.md](docs/dashboard.md) |
+| Troubleshooting | [docs/troubleshooting.md](docs/troubleshooting.md) |
 
 ## Roadmap
 
-- [x] Unit test coverage (#9)
-- [x] PostgreSQL as primary storage (#11)
-- [x] Configurable timezone and region (#12)
-- [x] Retry logic with exponential backoff (#13)
-- [x] Dockerfile security and modernization (#14)
-- [x] Database migrations with Alembic (#26)
-- [x] REST API for health, history, metrics, and notification management (#29)
-- [x] Web dashboard for game history (#46)
-- [x] Production end-to-end test suite (#49)
-- [x] Support for additional game stores — Steam (#56)
-- [x] Display original price and Steam country-specific pricing (#107)
-- [x] Unified `REGION` variable — one setting derives timezone, locale, and all store options (#117)
-- [x] Show review scores (Steam + Metacritic) in notifications and dashboard (#106)
-- [x] Differentiate DLCs from base games in notifications and dashboard (#109)
-- [x] Store filter in the web dashboard (#115)
-- [x] UI/UX Enhancements: status filter tabs, countdown timer, original price, review scores, expired card styling (#71)
-- [x] Pre-built Docker image on GHCR + self-hosting documentation (#128)
-- [ ] Add support for multiple notification channels (Discord, Slack, Telegram, etc.) (#55)
+- [x] Multi-store support (Epic + Steam)
+- [x] PostgreSQL storage with Alembic migrations
+- [x] REST API and web dashboard
+- [x] Region-aware localization (one variable, derived defaults)
+- [x] Review scores in notifications and dashboard
+- [x] DLC differentiation
+- [x] Pre-built Docker image on GHCR
+- [x] Structured JSON logging for Loki/Grafana
+- [ ] Multiple notification channels (Slack, Telegram, etc.) — [#55](https://github.com/JulioMoralesB/free-games-notifier/issues/55)
 
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+
+## Support
+
+- 🐛 [Report an issue](https://github.com/JulioMoralesB/free-games-notifier/issues)
+- 📦 [Container packages](https://github.com/JulioMoralesB/free-games-notifier/pkgs/container/free-games-notifier)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,69 @@
+# REST API Reference
+
+The service exposes a FastAPI REST API on `API_HOST:API_PORT` (default `0.0.0.0:8000`).
+
+**Interactive docs:** Open `http://<host>:<API_PORT>/docs` for the auto-generated Swagger UI with full schema details and a live request console.
+
+## Endpoints
+
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/health` | `GET` | — | Epic Games API and database connectivity check |
+| `/games/latest` | `GET` | — | Most recently fetched free games |
+| `/games/history` | `GET` | — | Paginated full game history |
+| `/notify/discord/resend` | `POST` | API key | Re-send the last Discord notification |
+| `/metrics` | `GET` | — | Uptime, games processed, notification counts, error counts |
+| `/config` | `GET` | API key | Non-secret runtime configuration |
+| `/check` | `POST` | API key | Full end-to-end pipeline test (fetch + notify) |
+| `/dashboard/` | `GET` | — | Web dashboard (served as static files) |
+
+## Authentication
+
+Endpoints marked **API key** require an `X-API-Key` header when the `API_KEY` environment variable is set. If `API_KEY` is left empty (the default), authentication is disabled and all endpoints are open — useful for local development but **not recommended in production**.
+
+```bash
+curl -H "X-API-Key: $API_KEY" http://localhost:8000/config
+```
+
+## Query parameters: `/games/history`
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `limit` | int (1-100) | `20` | Max games to return per page |
+| `offset` | int (≥0) | `0` | Number of games to skip |
+| `sort_by` | `end_date` \| `title` | `end_date` | Field to sort by |
+| `sort_dir` | `asc` \| `desc` | `desc` | Sort direction |
+| `store` | `all` \| `epic` \| `steam` | `all` | Filter by store |
+| `status` | `all` \| `active` \| `expired` | `all` | Filter by promotion status |
+
+Filtering and sorting are applied to the full dataset **before** pagination, so counts and ordering are consistent across pages.
+
+## Example: pagination
+
+```bash
+# First page
+curl http://localhost:8000/games/history?limit=10&offset=0
+
+# Next page
+curl http://localhost:8000/games/history?limit=10&offset=10
+
+# Currently free Epic games only
+curl "http://localhost:8000/games/history?store=epic&status=active"
+```
+
+## Example: end-to-end check
+
+The `/check` endpoint is useful for verifying the full pipeline (scraper → storage check → Discord notification) without affecting stored data:
+
+```bash
+curl -X POST -H "X-API-Key: $API_KEY" http://localhost:8000/check
+```
+
+You can override the Discord webhook URL for a single request — handy for testing in a separate channel:
+
+```bash
+curl -X POST -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"webhook_url":"https://discord.com/api/webhooks/.../..."}' \
+  http://localhost:8000/check
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,113 @@
+# Architecture
+
+A high-level overview of how the project is structured and how data flows through it.
+
+## Project layout
+
+```
+.
+├── main.py                       # Scheduler entry point + API server thread
+├── api.py                        # FastAPI REST API + dashboard static mount
+├── config.py                     # Environment variables + region profiles
+├── requirements.txt              # Python runtime dependencies
+├── requirements-dev.txt          # Test + lint dependencies
+├── alembic.ini                   # Alembic migration tool configuration
+├── alembic/versions/             # Versioned schema migration scripts
+├── compose.yaml                  # Docker Compose orchestration
+├── Dockerfile                    # Multi-stage image (Node builder → Python runtime)
+├── ruff.toml                     # Linter configuration
+│
+├── dashboard/                    # React + TypeScript SPA (Vite)
+│   └── src/
+│       ├── App.tsx               # Top-level state, filters, fetch loop
+│       ├── components/           # GameCard, LanguageSelector, Pagination, …
+│       └── i18n/                 # Translation strings (en, es)
+│
+├── modules/
+│   ├── models.py                 # FreeGame dataclass shared across modules
+│   ├── notifier.py               # Discord webhook sender + embed builder
+│   ├── storage.py                # Storage dispatcher (PostgreSQL or JSON file)
+│   ├── database.py               # PostgreSQL operations
+│   ├── healthcheck.py            # External health check pings
+│   ├── retry.py                  # Generic exponential-backoff helper
+│   ├── logging_config.py         # JSON structured logging setup
+│   └── scrapers/
+│       ├── base.py               # Scraper interface
+│       ├── epic.py               # Epic Games Store scraper
+│       ├── steam.py              # Steam Store scraper
+│       └── review_sources.py     # Steam reviews + Metacritic enrichment
+│
+├── tests/                        # pytest suite
+│   ├── conftest.py               # Shared fixtures
+│   ├── e2e/                      # Production smoke tests (marker: production)
+│   └── test_*.py                 # Unit + integration tests
+│
+└── docs/                         # Documentation (you are here)
+```
+
+## Data flow
+
+```
+┌──────────────┐
+│  Scheduler   │ — runs every CHECK_INTERVAL_HOURS or daily at SCHEDULE_TIME
+│  (main.py)   │
+└──────┬───────┘
+       │
+       ▼
+┌──────────────────────────────┐
+│  Scrapers (modules/scrapers) │
+│  - epic.py: GraphQL API      │
+│  - steam.py: HTML + JSON     │
+└──────┬───────────────────────┘
+       │  list[FreeGame]
+       ▼
+┌──────────────┐    diff vs ┌──────────────┐
+│  Deduper     │ ◀────────  │  Storage     │
+│  (main.py)   │            │  (storage.py)│
+└──────┬───────┘            └──────────────┘
+       │  new games
+       ▼
+┌──────────────┐
+│  Notifier    │ — Discord webhook with rich embed
+│ (notifier.py)│
+└──────┬───────┘
+       │
+       ▼
+┌──────────────┐
+│  Storage     │ — upsert all current games (preserves still-active across runs)
+└──────────────┘
+```
+
+The REST API runs on a daemon thread alongside the scheduler, exposing the same storage backend for read access.
+
+## Key design choices
+
+### Single FreeGame model
+
+Every scraper returns `list[FreeGame]` from `modules/models.py`. Adding a new store means implementing `Scraper.fetch_free_games() -> list[FreeGame]` — the rest of the pipeline is store-agnostic.
+
+### Pluggable storage
+
+`modules/storage.py` is a dispatcher: it picks PostgreSQL when `DB_HOST` is set, JSON file otherwise. Both backends implement the same `load_previous_games`, `save_games`, `load_last_notification`, `save_last_notification` interface, so the rest of the codebase doesn't care which is in use.
+
+### Deduplication strategy
+
+The notifier runs daily/hourly but should never send the same notification twice. `main._find_new_games` uses three independent checks:
+
+1. **Active URL set** — URLs whose promo end date is still in the future are suppressed
+2. **Recently expired URLs** — a 24-hour grace window after expiry suppresses re-notification when a store returns a wrong end date (e.g. Steam off-by-one-year)
+3. **(URL, end_date) seen set** — exact match on the URL + end_date pair from any past run
+
+A game must pass all three to be considered new.
+
+### Adding a new scraper
+
+1. Create `modules/scrapers/yourstore.py` with a class that subclasses `Scraper` (in `base.py`)
+2. Implement `store_name` and `fetch_free_games() -> list[FreeGame]`
+3. Register it in `modules/scrapers/__init__.py` so `get_enabled_scrapers(["yourstore"])` returns it
+4. Add an entry to the `ENABLED_STORES` validation list in `config.py`
+5. Update [`docs/configuration.md`](configuration.md) and [`README.md`](../README.md)
+
+### Adding a new dashboard language
+
+See the [Dashboard Developer Guide](dashboard.md#adding-a-new-language).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,90 @@
+# Configuration Reference
+
+All configuration is driven by environment variables. For Docker deployments, set them in a `.env` file at the repo root (copy from [`.env.example`](../.env.example) to start).
+
+## Required
+
+| Variable | Description |
+|----------|-------------|
+| `DISCORD_WEBHOOK_URL` | Discord webhook URL for sending notifications. Create one via **Server Settings → Integrations → Webhooks**. |
+
+## Region & Localization
+
+The `REGION` variable is the recommended way to localize the service — set one IANA timezone string and the rest is derived automatically.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REGION` | _(empty)_ | **Recommended.** IANA timezone string (e.g. `America/Mexico_City`). Derives `TIMEZONE`, `LOCALE`, `EPIC_GAMES_REGION`, `STEAM_LANGUAGE`, and `STEAM_COUNTRY`. Individual variables below take precedence when also set. Supported values are listed in [`.env.example`](../.env.example). |
+| `TIMEZONE` | `UTC` | IANA timezone for date display in notifications (e.g. `America/New_York`, `Europe/London`). |
+| `LOCALE` | `en_US.UTF-8` | Locale for date formatting (e.g. `es_MX.UTF-8`, `de_DE.UTF-8`). All locales supported by the built-in region profiles are pre-installed in the Docker image. |
+| `EPIC_GAMES_REGION` | `en-US` | Region code used in Epic Games Store links (e.g. `es-MX`, `de-DE`). |
+| `STEAM_LANGUAGE` | `english` | Language for Steam game descriptions (e.g. `spanish`, `french`). Full list: [Steam localization languages](https://partner.steamgames.com/doc/store/localization/languages). |
+| `STEAM_COUNTRY` | `US` | ISO 3166-1 alpha-2 country code for Steam store requests — controls price currency (e.g. `MX` → MXN, `DE` → EUR, `GB` → GBP). |
+
+## Stores
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLED_STORES` | `epic` | Comma-separated list of stores to scrape. Supported: `epic`, `steam` (e.g. `epic,steam`). |
+| `EPIC_GAMES_API_URL` | Official API | Override for the Epic Games Store API endpoint. |
+| `STEAM_REQUEST_DELAY_MS` | `1500` | Milliseconds to wait between Steam HTTP requests to avoid rate limiting. |
+
+## Database (Optional)
+
+Leave all `DB_*` variables empty to use JSON file storage. See [Storage Backends](storage-backends.md) for a comparison.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DB_HOST` | _(empty)_ | PostgreSQL host. Empty = file storage. |
+| `DB_PORT` | `5432` | PostgreSQL port. |
+| `DB_NAME` | _(empty)_ | PostgreSQL database name. |
+| `DB_USER` | _(empty)_ | PostgreSQL username. |
+| `DB_PASSWORD` | _(empty)_ | PostgreSQL password. |
+
+## Scheduler
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CHECK_INTERVAL_HOURS` | _(empty)_ | Run on a repeating interval (e.g. `6` = every 6 hours). Minimum: `1`. Recommended when Steam is enabled. Leave empty to use `SCHEDULE_TIME`. |
+| `SCHEDULE_TIME` | `12:00` | Daily check time in `HH:MM`, interpreted in `TIMEZONE`. Used only when `CHECK_INTERVAL_HOURS` is not set. |
+
+## Health Check Monitoring
+
+Optional integration with [Healthchecks.io](https://healthchecks.io/) or [UptimeKuma](https://github.com/louislam/uptime-kuma) for service monitoring.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HEALTHCHECK_URL` | _(empty)_ | Healthchecks.io or UptimeKuma ping URL. |
+| `ENABLE_HEALTHCHECK` | `false` | Enable health check pings. Only activate after setting `HEALTHCHECK_URL`. |
+| `HEALTHCHECK_INTERVAL` | `1` | Health check ping interval in minutes. |
+
+## REST API
+
+See the [API Reference](api.md) for endpoint documentation.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `API_HOST` | `0.0.0.0` | Interface the REST API and dashboard server binds to. |
+| `API_PORT` | `8000` | Port the REST API and dashboard server listens on. |
+| `API_KEY` | _(empty)_ | Secret key for protecting mutating API endpoints and `GET /config`. Leave empty to disable auth. |
+
+## Notifications
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATE_FORMAT` | `%B %d, %Y at %I:%M %p` | strftime format for the promotion end date in Discord notifications. |
+
+## Docker bind mounts
+
+Used by `compose.yaml` to persist data and logs on the host.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATA_PATH` | `./data` | Host directory bind-mounted to `/mnt/data` in the container. |
+| `LOGS_PATH` | `./logs` | Host directory bind-mounted to `/mnt/logs` in the container. |
+
+## Steam-specific notes
+
+- **Free promotions on Steam are infrequent.** When only Steam is enabled (or when Steam returns no results), the scheduler logs *"No free games found"* more often than with Epic — this is expected.
+- **Rate limiting:** Steam requests are throttled by `STEAM_REQUEST_DELAY_MS` (default 1500 ms) to avoid HTTP 429 errors. Lowering the delay can trigger rate limits; raising it is safe.
+- **Use `CHECK_INTERVAL_HOURS` with Steam.** Steam free games can appear at any time of day, unlike the predictable Epic Thursday rotation.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,89 @@
+# Local Development
+
+This guide covers running the service from source for development. For self-hosting via Docker, see the [Self-hosting Guide](self-hosting.md).
+
+## Prerequisites
+
+- Python 3.9+
+- pip and `venv`
+- Node.js 20+ and npm (only required to build or hot-reload the dashboard)
+
+## Setup
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/JulioMoralesB/free-games-notifier.git
+cd free-games-notifier
+```
+
+### 2. Create a virtual environment
+
+```bash
+python3 -m venv env
+source env/bin/activate  # On Windows: env\Scripts\activate
+```
+
+### 3. Install dependencies
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-dev.txt   # for tests + linter
+```
+
+### 4. Configure environment variables
+
+```bash
+cp .env.example .env
+```
+
+At minimum, set `DISCORD_WEBHOOK_URL` in `.env`. See the [Configuration Reference](configuration.md) for all options.
+
+### 5. Run the scheduler
+
+```bash
+python main.py
+```
+
+The scheduler logs to `/mnt/logs/notifier.log` by default. For local development, you can override the log path or simply tail stdout — both file and console handlers receive every entry.
+
+## Running the dashboard with hot-reload
+
+Open a second terminal:
+
+```bash
+cd dashboard
+npm install
+npm run dev     # http://localhost:5173/dashboard/
+```
+
+The Vite dev server proxies `/games` requests to `http://localhost:8000`, so the Python API only needs to be running.
+
+For production builds and instructions on adding a new language, see the [Dashboard Developer Guide](dashboard.md).
+
+## Running tests
+
+```bash
+pytest tests/ -v
+```
+
+Tests cover both file-backend and PostgreSQL-backend paths. File-backend tests explicitly set `DB_HOST=None` to remain hermetic.
+
+To run just the unit tests (excluding integration and production smoke tests):
+
+```bash
+pytest tests/ -v -m "not integration and not production"
+```
+
+## Linting
+
+```bash
+ruff check .
+ruff check . --fix    # auto-fix safe issues
+```
+
+## Branch workflow
+
+- All PRs target the `QA` branch — never `main` directly
+- `main` is the source of truth for releases; tags `v*.*.*` push images to GHCR
+- See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contribution guide (once published)

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,91 @@
+# Self-hosting Guide
+
+The easiest way to run Free Games Notifier on your own server is with the pre-built Docker image published on [GitHub Container Registry](https://github.com/JulioMoralesB/free-games-notifier/pkgs/container/free-games-notifier). No build step required.
+
+## Prerequisites
+
+- Docker 20.10+
+- Docker Compose v2 (`docker compose`) — Compose v1 (`docker-compose`) also works
+- A Discord webhook URL — create one via **Server Settings → Integrations → Webhooks** in your Discord server
+- (Optional) PostgreSQL 13+ for database-backed storage; the service falls back to JSON file storage when no DB is configured
+
+## Quick Start
+
+### 1. Get the files
+
+```bash
+git clone https://github.com/JulioMoralesB/free-games-notifier.git
+cd free-games-notifier
+```
+
+### 2. Configure environment variables
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and set at minimum:
+
+```env
+DISCORD_WEBHOOK_URL=https://discordapp.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_TOKEN
+```
+
+The file already includes sensible defaults for `DATA_PATH` (`./data`) and `LOGS_PATH` (`./logs`), which Docker bind-mounts for persistent storage and logs. Change them to absolute paths if you prefer a specific location.
+
+Optionally set `REGION` to your IANA timezone string (e.g. `America/Mexico_City`) — this derives timezone, locale, Steam language, and country in one step. See the [Configuration Reference](configuration.md) for all options.
+
+To enable PostgreSQL, uncomment and fill in the `DB_*` variables; otherwise JSON file storage is used automatically. See [Storage Backends](storage-backends.md) for a comparison.
+
+### 3. Start the service
+
+```bash
+docker compose pull   # pull the pre-built image from ghcr.io
+docker compose up -d
+```
+
+Docker Compose creates the `data/` and `logs/` directories and the internal network on first run. The service applies any pending database migrations and begins the scheduling loop.
+
+The dashboard and REST API are available at `http://localhost:8000`.
+
+> **Building from source:** If you'd rather build the image locally (e.g. for testing local changes), skip `docker compose pull` and run `docker compose up -d --build` instead.
+
+## Database migrations
+
+When `DB_HOST` is configured, Alembic migrations run **automatically on startup** — no manual step is needed. Migration log lines on first boot are expected. For manual migration commands, see [Database Migrations](database-migrations.md).
+
+## Pinning to a specific version
+
+`compose.yaml` uses `:latest` by default. For reproducible deployments, pin to a specific semver tag:
+
+```yaml
+# compose.yaml
+image: ghcr.io/juliomoralesb/free-games-notifier:1.2.3
+```
+
+Available versions are listed on the [packages page](https://github.com/JulioMoralesB/free-games-notifier/pkgs/container/free-games-notifier).
+
+## Updating
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+This pulls the latest image and restarts the service. Any new migrations run automatically on startup.
+
+## Using only Docker (no Compose)
+
+```bash
+docker run -d \
+  --name free-games-notifier \
+  -e DISCORD_WEBHOOK_URL="YOUR_WEBHOOK_URL" \
+  -e REGION=America/New_York \
+  -v /your/data/path:/mnt/data \
+  -v /your/logs/path:/mnt/logs \
+  -p 8000:8000 \
+  ghcr.io/juliomoralesb/free-games-notifier:latest
+```
+
+## Troubleshooting
+
+See the [Troubleshooting Guide](troubleshooting.md) for common issues and their solutions.

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -1,0 +1,51 @@
+# Storage Backends
+
+The notifier automatically selects a storage backend based on the `DB_HOST` environment variable.
+
+| `DB_HOST` set? | Backend | Data location |
+|---|---|---|
+| ✅ Yes | PostgreSQL (`free_games` schema) | Remote database |
+| ❌ No (default) | JSON file | `/mnt/data/free_games.json` (inside the container) |
+
+## Which one should I use?
+
+**Use the JSON file backend** if:
+- You're running a single instance on a single machine
+- You don't already have a PostgreSQL server
+- You want zero external dependencies
+
+**Use PostgreSQL** if:
+- You already run a PostgreSQL server for other home-server services
+- You want to query the data directly (e.g. for custom dashboards)
+- You expect the game history to grow large enough that JSON parsing becomes noticeable
+- You're running multiple instances that need to share state
+
+## How the backends differ
+
+### JSON file backend (default)
+
+- Single file: `/mnt/data/free_games.json` (bind-mounted via `DATA_PATH` in `compose.yaml`)
+- Loaded fully into memory on every check; suitable for thousands of games
+- The container creates the file on first run if it doesn't exist
+- Backups: copy the file
+
+### PostgreSQL backend
+
+- Schema: `free_games`, table: `games`
+- `game_id` is derived from the game's `link` and used as the conflict key for upserts (`ON CONFLICT (game_id) DO UPDATE`)
+- Schema is created automatically on startup, and any pending Alembic migrations are applied — no manual setup needed
+- A second table, `last_notification`, stores the most recent Discord batch for the resend endpoint
+- For migration details, see [Database Migrations](database-migrations.md)
+
+## Switching from JSON to PostgreSQL
+
+1. Stand up a PostgreSQL instance (any 13+ should work)
+2. Add `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` to your `.env`
+3. Restart the container — the schema is created and any existing JSON data is **not** automatically imported
+4. (Optional) If you want to preserve history, you can re-insert the JSON file's records via SQL before starting the container
+
+## Switching from PostgreSQL to JSON
+
+1. Remove or comment out the `DB_*` variables in `.env`
+2. Restart the container — the service falls back to JSON file storage
+3. PostgreSQL data is left untouched in the database; you can re-enable it later

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,5 +47,5 @@ docker logs free-games-notifier
 docker restart free-games-notifier
 
 # Stop and remove
-docker-compose down
+docker compose down
 ```


### PR DESCRIPTION
## Summary

- **README slimmed from 344 → 65 lines** — now an index with tagline, screenshot, 5-line quick start, and a links table to detailed docs
- **Six new focused docs** under \`docs/\`:
  - \`self-hosting.md\` — full Docker walkthrough, version pinning, updating, no-Compose alternative
  - \`configuration.md\` — complete environment variable reference (grouped by concern: region, stores, DB, scheduler, etc.)
  - \`api.md\` — REST API endpoints, auth, query params, usage examples
  - \`storage-backends.md\` — PostgreSQL vs JSON decision matrix + switching steps
  - \`local-development.md\` — running from source with venv, dashboard hot-reload, tests, lint
  - \`architecture.md\` — project layout, data flow diagram, design choices, how to add a scraper
- **Bonus:** updated \`docs/troubleshooting.md\` to use Compose v2 syntax (\`docker compose down\`)

## Why

The original README tried to be quick start, deep config reference, API documentation, architecture overview, and contributor guide all at once — 344 lines is overwhelming for first-time visitors and inefficient for returning users looking up a specific detail.

The new structure follows the convention used by similar self-hosted projects (Linkwarden, Karakeep, etc.): a small README that gets you running, with a clear table of contents to specialized docs.

## Out of scope

The \`docs/Steam Search.html\` and \`docs/steam-research.md\` cleanup is tracked separately in #159, and the \`docker-compose\` references in the main README are tracked in #160 (only the troubleshooting one was touched here as part of moving content around).

## Test plan

- [ ] All internal doc links resolve on GitHub web UI
- [ ] README renders cleanly with the screenshot at the top
- [ ] No content from the old README is lost (just relocated)

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)