### PR TITLE
refactor: extract dedupe and DB lifecycle from main.py

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,8 @@ A high-level overview of how the project is structured and how data flows throug
 │   ├── notifier.py               # Discord webhook sender + embed builder
 │   ├── storage.py                # Storage dispatcher (PostgreSQL or JSON file)
 │   ├── database.py               # PostgreSQL operations
+│   ├── dedupe.py                 # New-game detection + grace-period guards
+│   ├── db_lifecycle.py           # Alembic migrations + post-migration sanity check
 │   ├── healthcheck.py            # External health check pings
 │   ├── retry.py                  # Generic exponential-backoff helper
 │   ├── logging_config.py         # JSON structured logging setup

--- a/main.py
+++ b/main.py
@@ -1,30 +1,23 @@
 import logging
-import os
 import threading
 import time
-from datetime import datetime, timedelta, timezone
 
-import psycopg2
 import requests
 import schedule
-from alembic.config import Config as AlembicConfig
 
-from alembic import command as alembic_command
 from config import (
     API_HOST,
     API_PORT,
     CHECK_INTERVAL_HOURS,
     DB_HOST,
-    DB_NAME,
-    DB_PASSWORD,
-    DB_PORT,
-    DB_USER,
     ENABLED_STORES,
     HEALTHCHECK_INTERVAL,
     SCHEDULE_TIME,
     TIMEZONE,
 )
 from modules.database import FreeGamesDatabase
+from modules.db_lifecycle import run_db_migrations, verify_required_tables
+from modules.dedupe import find_new_games, is_still_active
 from modules.healthcheck import healthcheck
 from modules.logging_config import setup_logging
 from modules.notifier import send_discord_message
@@ -46,131 +39,7 @@ class _HealthEndpointFilter(logging.Filter):
         return ' /health ' not in record.getMessage()
 
 
-def _is_still_active(game) -> bool:
-    """Return True if *game*'s promotion has not yet expired.
-
-    Games with an empty or un-parseable end_date are treated as still-active to
-    avoid false "new game" alerts caused by transient scraping failures.
-    """
-    end_date = game.end_date
-    if not end_date:
-        # Treat unknown end dates as active to avoid duplicate notifications.
-        return True
-
-    normalized = end_date.strip()
-    if normalized.endswith("Z"):
-        normalized = normalized[:-1] + "+00:00"
-
-    try:
-        ends_at = datetime.fromisoformat(normalized)
-    except ValueError:
-        # Keep legacy/malformed records from causing false "new" alerts.
-        return True
-
-    if ends_at.tzinfo is None:
-        ends_at = ends_at.replace(tzinfo=timezone.utc)
-
-    return ends_at >= datetime.now(timezone.utc)
-
-
-_RECENTLY_EXPIRED_GRACE_PERIOD_HOURS = 24
-
-
-def _recently_expired_urls(previous_games) -> set[str]:
-    """Return URLs whose promo expired within the last grace period.
-
-    Steam (and other stores) occasionally return a wrong end_date for a game
-    whose promo just ended (e.g. off-by-one year).  Without this guard,
-    a URL that expired minutes ago would pass both the ``previous_active_urls``
-    and ``previous_seen`` checks and trigger a duplicate notification.
-    """
-    now = datetime.now(timezone.utc)
-    grace = timedelta(hours=_RECENTLY_EXPIRED_GRACE_PERIOD_HOURS)
-    urls: set[str] = set()
-    for game in previous_games:
-        if not game.url or not game.end_date:
-            continue
-        normalized = game.end_date.strip()
-        if normalized.endswith("Z"):
-            normalized = normalized[:-1] + "+00:00"
-        try:
-            ends_at = datetime.fromisoformat(normalized)
-        except ValueError:
-            continue
-        if ends_at.tzinfo is None:
-            ends_at = ends_at.replace(tzinfo=timezone.utc)
-        if ends_at < now <= ends_at + grace:
-            urls.add(game.url)
-    return urls
-
-
-def _find_new_games(current_games, previous_games):
-    """Return games that are newly free compared to still-active previous promos.
-
-    Three checks prevent duplicate notifications:
-
-    1. ``previous_active_urls`` — URLs whose promos are still running.  A game
-       whose URL is already active is suppressed regardless of its end_date.
-    2. ``recently_expired_urls`` — URLs whose promo ended within the last
-       ``_RECENTLY_EXPIRED_GRACE_PERIOD_HOURS`` hours.  This prevents a store
-       returning a bad end_date (e.g. wrong year) right after expiry from
-       triggering a re-notification for the same promotion.
-    3. ``previous_seen`` — (url, end_date) pairs ever persisted.  Prevents
-       re-notification for an expired promo even if the URL no longer appears
-       in the active set.
-
-    A game that passes *all* checks is genuinely new or has started a fresh
-    promo with a different end_date after the grace period.
-
-    Same-run deduplication: ``notified_urls`` tracks URLs already added to
-    ``new_games`` in this loop so that a URL appearing twice in ``current_games``
-    (e.g. duplicate search-result rows) is only notified once.
-    """
-    # A (url, end_date) pair that already appeared in previous games should not
-    # trigger a new notification, regardless of whether the promo is still active.
-    # This prevents re-notifying for the same expired promo while still allowing
-    # re-notification when the same game has a new promo (different end_date).
-    previous_seen = {
-        (game.url, game.end_date)
-        for game in previous_games
-        if game.url
-    }
-
-    # Also track active URLs to suppress games seen before whose promos are still running.
-    previous_active_urls = {
-        game.url
-        for game in previous_games
-        if game.url and _is_still_active(game)
-    }
-
-    # Suppress re-notification for URLs whose promo just expired — store data
-    # errors (e.g. Steam returning a wrong year) would otherwise bypass both
-    # previous_active_urls and previous_seen when the end_date differs.
-    recently_expired = _recently_expired_urls(previous_games)
-
-    new_games = []
-    notified_urls: set[str] = set()
-    for game in current_games:
-        url = game.url
-        if url:
-            if (
-                url not in previous_active_urls
-                and url not in recently_expired
-                and (url, game.end_date) not in previous_seen
-                and url not in notified_urls
-            ):
-                new_games.append(game)
-                notified_urls.add(url)
-            continue
-
-        # Fallback for malformed records that do not have a url.
-        if game not in previous_games:
-            new_games.append(game)
-
-    return new_games
-
 def check_games():
-
     """Main execution function that checks for new free games and sends Discord notification."""
     logger.info("Checking for new free games...")
 
@@ -204,7 +73,7 @@ def check_games():
         logger.error("Failed to load previous games: %s", e)
         return
 
-    new_games = _find_new_games(current_games, previous_games)
+    new_games = find_new_games(current_games, previous_games)
 
     if new_games:
         logger.info("Found %d new free games! Sending Discord notification...", len(new_games))
@@ -251,7 +120,7 @@ def check_games():
     stores_with_results = {g.store for g in current_games}
     preserved = [
         g for g in previous_games
-        if g.store not in stores_with_results and _is_still_active(g)
+        if g.store not in stores_with_results and is_still_active(g)
     ]
     if preserved:
         logger.info(
@@ -271,41 +140,6 @@ def check_games():
     except Exception as e:
         logger.error("Unexpected error saving games: %s", e)
         logger.warning("Failed to update local cache.")
-
-def _run_db_migrations():
-    """Apply any pending Alembic migrations up to the latest revision."""
-    logger.info("Applying database migrations...")
-    # Suppress verbose per-revision Alembic log lines from service logs.
-    # env.py skips fileConfig when the service's logging is already configured,
-    # but raise the level here as well to guard against any propagation.
-    logging.getLogger("alembic").setLevel(logging.WARNING)
-    cfg = AlembicConfig(os.path.join(os.path.dirname(__file__), "alembic.ini"))
-    alembic_command.upgrade(cfg, "head")
-    logger.info("Database migrations applied successfully.")
-
-
-def _verify_required_tables():
-    """Fail fast when required DB tables are missing after migrations."""
-    logger.info("Verifying required database tables...")
-
-    conn_params = {
-        "host": DB_HOST,
-        "port": DB_PORT,
-        "dbname": DB_NAME,
-        "user": DB_USER,
-        "password": DB_PASSWORD,
-    }
-
-    with psycopg2.connect(**conn_params) as conn:
-        with conn.cursor() as cursor:
-            cursor.execute("SELECT to_regclass('free_games.last_notification')")
-            if cursor.fetchone()[0] is None:
-                raise RuntimeError(
-                    "Required table free_games.last_notification is missing after migrations. "
-                    "Run 'alembic upgrade head' and verify DB permissions."
-                )
-
-    logger.info("Required database tables verified successfully.")
 
 
 def _start_api_server():
@@ -327,8 +161,8 @@ def main():
         logger.info("Database configuration detected. Initializing database...")
         db = FreeGamesDatabase()
         db.init_db()
-        _run_db_migrations()
-        _verify_required_tables()
+        run_db_migrations()
+        verify_required_tables()
     else:
         logger.info("No database configuration detected. Using JSON file storage.")
 
@@ -365,6 +199,7 @@ def main():
     while True:
         schedule.run_pending()
         time.sleep(1)
+
 
 if __name__ == "__main__":
     logger.info("Starting service...")

--- a/modules/db_lifecycle.py
+++ b/modules/db_lifecycle.py
@@ -1,0 +1,55 @@
+"""Database lifecycle helpers: Alembic migrations and post-migration sanity checks.
+
+These helpers are invoked from the scheduler entry point at startup when
+``DB_HOST`` is configured.  They isolate the database-bootstrap logic from
+the rest of ``main.py``, making each step testable in isolation.
+"""
+
+import logging
+import os
+
+import psycopg2
+from alembic.config import Config as AlembicConfig
+
+from alembic import command as alembic_command
+from config import DB_HOST, DB_NAME, DB_PASSWORD, DB_PORT, DB_USER
+
+logger = logging.getLogger(__name__)
+
+
+def run_db_migrations() -> None:
+    """Apply any pending Alembic migrations up to the latest revision."""
+    logger.info("Applying database migrations...")
+    # Suppress verbose per-revision Alembic log lines from service logs.
+    # env.py skips fileConfig when the service's logging is already configured,
+    # but raise the level here as well to guard against any propagation.
+    logging.getLogger("alembic").setLevel(logging.WARNING)
+    cfg = AlembicConfig(
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), "alembic.ini")
+    )
+    alembic_command.upgrade(cfg, "head")
+    logger.info("Database migrations applied successfully.")
+
+
+def verify_required_tables() -> None:
+    """Fail fast when required DB tables are missing after migrations."""
+    logger.info("Verifying required database tables...")
+
+    conn_params = {
+        "host": DB_HOST,
+        "port": DB_PORT,
+        "dbname": DB_NAME,
+        "user": DB_USER,
+        "password": DB_PASSWORD,
+    }
+
+    with psycopg2.connect(**conn_params) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT to_regclass('free_games.last_notification')")
+            if cursor.fetchone()[0] is None:
+                raise RuntimeError(
+                    "Required table free_games.last_notification is missing after migrations. "
+                    "Run 'alembic upgrade head' and verify DB permissions."
+                )
+
+    logger.info("Required database tables verified successfully.")

--- a/modules/dedupe.py
+++ b/modules/dedupe.py
@@ -1,0 +1,143 @@
+"""Game deduplication logic for the scheduler.
+
+Determines which scraped games are *new* compared to what was previously
+seen, while guarding against three classes of false positives:
+
+1. **Active duplicates** — a previously-seen URL whose promo is still running.
+2. **Recently-expired URLs** — a URL whose promo just ended; the store may
+   briefly return a wrong ``end_date`` (e.g. Steam off-by-one-year) and we
+   suppress re-notifications for a grace window after expiry.
+3. **Exact (URL, end_date) replays** — never re-notify a pair we have
+   already persisted.
+
+The functions here are pure: no I/O, no scheduling, no external dependencies
+beyond ``datetime``.  They are easy to test in isolation.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+#: Window after a promotion's expiry during which re-notification is suppressed,
+#: even if the store returns a fresh-looking ``end_date``.  Tunable; 24 hours
+#: matches the typical Epic / Steam free-promo cadence.
+RECENTLY_EXPIRED_GRACE_PERIOD_HOURS = 24
+
+
+def is_still_active(game) -> bool:
+    """Return True if *game*'s promotion has not yet expired.
+
+    Games with an empty or un-parseable ``end_date`` are treated as still-active
+    to avoid false "new game" alerts caused by transient scraping failures.
+    """
+    end_date = game.end_date
+    if not end_date:
+        return True
+
+    normalized = end_date.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+
+    try:
+        ends_at = datetime.fromisoformat(normalized)
+    except ValueError:
+        # Keep legacy/malformed records from causing false "new" alerts.
+        return True
+
+    if ends_at.tzinfo is None:
+        ends_at = ends_at.replace(tzinfo=timezone.utc)
+
+    return ends_at >= datetime.now(timezone.utc)
+
+
+def _recently_expired_urls(previous_games) -> set[str]:
+    """Return URLs whose promo expired within the last grace period.
+
+    Steam (and other stores) occasionally return a wrong ``end_date`` for a game
+    whose promo just ended (e.g. off-by-one year).  Without this guard, a URL
+    that expired minutes ago would pass both the ``previous_active_urls`` and
+    ``previous_seen`` checks and trigger a duplicate notification.
+    """
+    now = datetime.now(timezone.utc)
+    grace = timedelta(hours=RECENTLY_EXPIRED_GRACE_PERIOD_HOURS)
+    urls: set[str] = set()
+    for game in previous_games:
+        if not game.url or not game.end_date:
+            continue
+        normalized = game.end_date.strip()
+        if normalized.endswith("Z"):
+            normalized = normalized[:-1] + "+00:00"
+        try:
+            ends_at = datetime.fromisoformat(normalized)
+        except ValueError:
+            continue
+        if ends_at.tzinfo is None:
+            ends_at = ends_at.replace(tzinfo=timezone.utc)
+        if ends_at < now <= ends_at + grace:
+            urls.add(game.url)
+    return urls
+
+
+def find_new_games(current_games, previous_games):
+    """Return games that are newly free compared to still-active previous promos.
+
+    Three checks prevent duplicate notifications:
+
+    1. ``previous_active_urls`` — URLs whose promos are still running.  A game
+       whose URL is already active is suppressed regardless of its end_date.
+    2. ``recently_expired_urls`` — URLs whose promo ended within the last
+       :data:`RECENTLY_EXPIRED_GRACE_PERIOD_HOURS` hours.  This prevents a store
+       returning a bad end_date (e.g. wrong year) right after expiry from
+       triggering a re-notification for the same promotion.
+    3. ``previous_seen`` — (url, end_date) pairs ever persisted.  Prevents
+       re-notification for an expired promo even if the URL no longer appears
+       in the active set.
+
+    A game that passes *all* checks is genuinely new or has started a fresh
+    promo with a different end_date after the grace period.
+
+    Same-run deduplication: ``notified_urls`` tracks URLs already added to
+    ``new_games`` in this loop so that a URL appearing twice in
+    ``current_games`` (e.g. duplicate search-result rows) is only notified
+    once.
+    """
+    # A (url, end_date) pair that already appeared in previous games should not
+    # trigger a new notification, regardless of whether the promo is still active.
+    # This prevents re-notifying for the same expired promo while still allowing
+    # re-notification when the same game has a new promo (different end_date).
+    previous_seen = {
+        (game.url, game.end_date)
+        for game in previous_games
+        if game.url
+    }
+
+    # Also track active URLs to suppress games seen before whose promos are still running.
+    previous_active_urls = {
+        game.url
+        for game in previous_games
+        if game.url and is_still_active(game)
+    }
+
+    # Suppress re-notification for URLs whose promo just expired — store data
+    # errors (e.g. Steam returning a wrong year) would otherwise bypass both
+    # previous_active_urls and previous_seen when the end_date differs.
+    recently_expired = _recently_expired_urls(previous_games)
+
+    new_games = []
+    notified_urls: set[str] = set()
+    for game in current_games:
+        url = game.url
+        if url:
+            if (
+                url not in previous_active_urls
+                and url not in recently_expired
+                and (url, game.end_date) not in previous_seen
+                and url not in notified_urls
+            ):
+                new_games.append(game)
+                notified_urls.add(url)
+            continue
+
+        # Fallback for malformed records that do not have a url.
+        if game not in previous_games:
+            new_games.append(game)
+
+    return new_games

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -29,15 +29,15 @@ def _import_main():
 
 
 class TestRunDbMigrations:
-    """Tests for main._run_db_migrations()."""
+    """Tests for main.run_db_migrations()."""
 
     def test_calls_alembic_upgrade_head(self):
         """_run_db_migrations should invoke alembic upgrade with 'head'."""
         main = _import_main()
 
         mock_upgrade = MagicMock()
-        with patch("main.alembic_command.upgrade", mock_upgrade):
-            main._run_db_migrations()
+        with patch("modules.db_lifecycle.alembic_command.upgrade", mock_upgrade):
+            main.run_db_migrations()
 
         assert mock_upgrade.call_count == 1
         _, upgrade_target = mock_upgrade.call_args[0]
@@ -55,8 +55,8 @@ class TestRunDbMigrations:
         def capture_upgrade(cfg, target):
             captured_cfg["cfg"] = cfg
 
-        with patch("main.alembic_command.upgrade", side_effect=capture_upgrade):
-            main._run_db_migrations()
+        with patch("modules.db_lifecycle.alembic_command.upgrade", side_effect=capture_upgrade):
+            main.run_db_migrations()
 
         assert isinstance(captured_cfg["cfg"], AlembicConfig)
 
@@ -64,13 +64,13 @@ class TestRunDbMigrations:
         """_run_db_migrations should not swallow exceptions from alembic."""
         main = _import_main()
 
-        with patch("main.alembic_command.upgrade", side_effect=RuntimeError("db error")):
+        with patch("modules.db_lifecycle.alembic_command.upgrade", side_effect=RuntimeError("db error")):
             with pytest.raises(RuntimeError, match="db error"):
-                main._run_db_migrations()
+                main.run_db_migrations()
 
 
 class TestVerifyRequiredTables:
-    """Tests for main._verify_required_tables()."""
+    """Tests for main.verify_required_tables()."""
 
     def test_succeeds_when_last_notification_exists(self):
         """Verification should pass when the required table exists."""
@@ -83,8 +83,8 @@ class TestVerifyRequiredTables:
         mock_conn.__enter__.return_value = mock_conn
         mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
 
-        with patch("main.psycopg2.connect", return_value=mock_conn):
-            main._verify_required_tables()
+        with patch("modules.db_lifecycle.psycopg2.connect", return_value=mock_conn):
+            main.verify_required_tables()
 
     def test_raises_when_last_notification_is_missing(self):
         """Verification should fail fast when last_notification table is absent."""
@@ -97,9 +97,9 @@ class TestVerifyRequiredTables:
         mock_conn.__enter__.return_value = mock_conn
         mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
 
-        with patch("main.psycopg2.connect", return_value=mock_conn):
+        with patch("modules.db_lifecycle.psycopg2.connect", return_value=mock_conn):
             with pytest.raises(RuntimeError, match="last_notification"):
-                main._verify_required_tables()
+                main.verify_required_tables()
 
 
 class TestMainDbBranch:
@@ -112,8 +112,8 @@ class TestMainDbBranch:
         mock_db = MagicMock()
         with patch("main.DB_HOST", "localhost"), \
              patch("main.FreeGamesDatabase", return_value=mock_db), \
-             patch("main._run_db_migrations") as mock_migrate, \
-             patch("main._verify_required_tables") as mock_verify_tables, \
+             patch("main.run_db_migrations") as mock_migrate, \
+             patch("main.verify_required_tables") as mock_verify_tables, \
              patch("main._start_api_server"), \
              patch("main.check_games"), \
              patch("main.healthcheck"), \
@@ -133,8 +133,8 @@ class TestMainDbBranch:
         main = _import_main()
 
         with patch("main.DB_HOST", None), \
-             patch("main._run_db_migrations") as mock_migrate, \
-             patch("main._verify_required_tables") as mock_verify_tables, \
+             patch("main.run_db_migrations") as mock_migrate, \
+             patch("main.verify_required_tables") as mock_verify_tables, \
              patch("main.FreeGamesDatabase") as mock_db_cls, \
              patch("main._start_api_server"), \
              patch("main.check_games"), \
@@ -399,7 +399,7 @@ class TestFindNewGamesEdgeCases:
             )
         ]
 
-        result = main._find_new_games(current_games, previous_games)
+        result = main.find_new_games(current_games, previous_games)
 
         assert result == [], "Missing end_date should be treated as active; no new games expected"
 
@@ -422,7 +422,7 @@ class TestFindNewGamesEdgeCases:
             )
         ]
 
-        result = main._find_new_games(current_games, previous_games)
+        result = main.find_new_games(current_games, previous_games)
 
         assert result == [], "empty end_date should be treated as active; no new games expected"
 
@@ -445,7 +445,7 @@ class TestFindNewGamesEdgeCases:
             )
         ]
 
-        result = main._find_new_games(current_games, previous_games)
+        result = main.find_new_games(current_games, previous_games)
 
         assert result == [], "Malformed end_date should be treated as active; no new games expected"
 
@@ -469,7 +469,7 @@ class TestFindNewGamesEdgeCases:
             )
         ]
 
-        result = main._find_new_games(current_games, previous_games)
+        result = main.find_new_games(current_games, previous_games)
 
         assert result == [], "Naive far-future end_date should be treated as active after UTC assignment"
 
@@ -492,7 +492,7 @@ class TestFindNewGamesEdgeCases:
             )
         ]
 
-        result = main._find_new_games(current_games, previous_games)
+        result = main.find_new_games(current_games, previous_games)
 
         assert result == current_games, "Naive past end_date should be treated as expired; game should appear as new"
 
@@ -532,7 +532,7 @@ class TestFindNewGamesEdgeCases:
             )
         ]
 
-        result = main._find_new_games(current_games, previous_games)
+        result = main.find_new_games(current_games, previous_games)
 
         assert result == [], (
             "A recently-expired game returning a different end_date should not "
@@ -569,7 +569,7 @@ class TestFindNewGamesEdgeCases:
             )
         ]
 
-        result = main._find_new_games(current_games, previous_games)
+        result = main.find_new_games(current_games, previous_games)
 
         assert result == current_games, (
             "A game that was free long ago and is now free again should trigger "


### PR DESCRIPTION
## Summary

\`main.py\` shrinks from **371 to 206 lines** (44% reduction) by extracting two self-contained concerns into their own modules. Behaviour is unchanged; the file is now 99% orchestration.

## New modules

### \`modules/dedupe.py\` — 143 lines

Pure business logic — no I/O, no scheduling, no external dependencies beyond \`datetime\`. Houses:

- \`find_new_games(current_games, previous_games)\` — the three-check deduplication entry point
- \`is_still_active(game)\` — end_date parsing + \"active\" classification
- \`_recently_expired_urls(previous_games)\` — grace-period helper
- \`RECENTLY_EXPIRED_GRACE_PERIOD_HOURS\` — tunable constant

Trivially testable in isolation; \`tests/test_migrations.py::TestCheckGamesDedupe\` and \`TestFindNewGamesEdgeCases\` keep passing with updated patch targets.

### \`modules/db_lifecycle.py\` — 55 lines

Database bootstrap helpers:

- \`run_db_migrations()\` — Alembic upgrade head with logger volume control
- \`verify_required_tables()\` — fail-fast sanity check post-migration

Renamed from the old underscore-prefixed names to make the public-API intent explicit.

## What stays in main.py

Per the issue's explicit out-of-scope note, \`_start_api_server\` and the \`_HealthEndpointFilter\` class stay here — they're tightly coupled to the threading + scheduler setup, and moving them adds churn without proportional benefit.

## Test patch updates

| Before | After |
|---|---|
| \`patch(\"main.alembic_command.upgrade\")\` | \`patch(\"modules.db_lifecycle.alembic_command.upgrade\")\` |
| \`patch(\"main.psycopg2.connect\")\` | \`patch(\"modules.db_lifecycle.psycopg2.connect\")\` |
| \`patch(\"main._run_db_migrations\")\` | \`patch(\"main.run_db_migrations\")\` |
| \`patch(\"main._verify_required_tables\")\` | \`patch(\"main.verify_required_tables\")\` |
| \`main._find_new_games(...)\` | \`main.find_new_games(...)\` |

## Test plan

- [x] \`ruff check .\` — clean
- [x] \`pytest tests/\` — 345 passed, 1 skipped, 11 deselected
- [x] \`docs/architecture.md\` updated to list the new modules

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)