### PR TITLE
chore: add OSS scaffolding (CONTRIBUTING, SECURITY, templates, CoC)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+<!-- One sentence: what is broken? -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behaviour
+
+<!-- What did you expect to happen? -->
+
+## Actual behaviour
+
+<!-- What happened instead? Include relevant log lines (set ENABLE_HEALTHCHECK=false if logs are noisy). -->
+
+```
+<paste relevant log lines here — redact webhook tokens, DB credentials, etc.>
+```
+
+## Environment
+
+- **Version**: <!-- e.g. ghcr.io/juliomoralesb/free-games-notifier:1.2.3 — find it via `docker inspect` or look at the running tag -->
+- **Deployment**: <!-- Docker Compose / standalone Docker / running from source -->
+- **Storage backend**: <!-- PostgreSQL / JSON file -->
+- **Region / TIMEZONE / LOCALE**: <!-- as set in your .env -->
+- **Enabled stores**: <!-- e.g. epic,steam -->
+- **OS / Architecture**: <!-- e.g. Ubuntu 24.04 amd64, Raspberry Pi OS arm64 -->
+
+## Additional context
+
+<!-- Screenshots, related issues, anything else that helps. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/JulioMoralesB/free-games-notifier/discussions
+    about: For general questions, configuration help, or design discussions, please use Discussions instead of opening an issue.
+  - name: Security vulnerability
+    url: https://github.com/JulioMoralesB/free-games-notifier/security/advisories/new
+    about: Report security issues privately via GitHub Security Advisories — do NOT open a public issue. See SECURITY.md for details.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Use case
+
+<!-- What problem are you trying to solve? Describe the situation, not the solution. -->
+
+## Proposed solution
+
+<!-- How would you like the project to solve it? Be as specific as you can. -->
+
+## Alternatives considered
+
+<!-- What other approaches did you think about, and why did you reject them? "I didn't" is a valid answer. -->
+
+## Additional context
+
+<!-- Screenshots, links to similar features in other projects, related issues, etc. -->
+
+## Are you willing to contribute?
+
+<!-- Optional. -->
+
+- [ ] I'd like to implement this myself and open a PR
+- [ ] I'd like guidance on how to implement this
+- [ ] I'm just suggesting; happy to leave it to the maintainer

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+Thanks for opening a PR!
+
+Reminders:
+- Target the `QA` branch, never `main` directly
+- Run `pytest tests/`, `cd dashboard && npm test`, and `ruff check .` locally before pushing
+- Include `Closes #N` below if this PR resolves an issue (the project board automation depends on it)
+- See CONTRIBUTING.md for the full contribution guide
+-->
+
+## Summary
+
+<!-- 1–3 bullet points of the user-facing change. If this is purely internal, say so explicitly. -->
+
+-
+
+## Test plan
+
+<!-- What did you actually run? Be honest — CI will tell us if the tests themselves work. -->
+
+- [ ]
+- [ ]
+
+## Closes
+
+<!-- e.g. Closes #123. Remove this section if the PR isn't tied to an issue. -->
+
+Closes #

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Code of Conduct
+
+This project adopts the **[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)**.
+
+The full text — covering expected behaviour, enforcement responsibilities, scope, and consequences — is available at the link above. By participating in this project (issues, pull requests, discussions) you agree to abide by it.
+
+## Reporting
+
+To report a concern, contact the project maintainer privately:
+
+- **Email**: <juliomoralesbd@gmail.com>
+- **Subject line**: `[CoC] free-games-notifier`
+
+All reports are handled discreetly. The reporter's identity is kept confidential to the extent possible while still allowing the report to be investigated and acted on.
+
+## Why this version
+
+Contributor Covenant 2.1 is the most widely adopted CoC in the open-source ecosystem (used by the Linux kernel, Kubernetes, Rails, and tens of thousands of other projects). Linking to the canonical text instead of copying it means this project automatically benefits from upstream clarifications without requiring a PR every time the spec evolves.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,131 @@
+# Contributing to Free Games Notifier
+
+Thanks for your interest in contributing! This guide covers everything you need to know to get a development environment up and submit a useful pull request.
+
+If you only want to **use** the project, see the [Self-hosting Guide](docs/self-hosting.md) instead.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). Be kind, assume good intent, and report unacceptable behaviour to the maintainer at <juliomoralesbd@gmail.com>.
+
+## Reporting bugs and requesting features
+
+Use the issue templates that appear automatically when you click **New Issue**. They prompt for the information that makes triage fast (repro steps, environment, expected vs actual). For security vulnerabilities, follow [SECURITY.md](SECURITY.md) — do **not** open a public issue.
+
+## Branch model
+
+```
+feature branch ──► QA ──► main ──► tag vX.Y.Z ──► GHCR image
+```
+
+- All PRs target the **`QA`** branch — never `main` directly. \`QA\` accumulates changes until they are ready for a release; `main` is the source of truth for release tags.
+- A maintainer fast-forwards `main` from `QA` and tags `vX.Y.Z` to publish a release. Pushing the tag triggers `.github/workflows/release.yml`, which builds the multi-arch Docker image and publishes it to `ghcr.io/juliomoralesb/free-games-notifier`.
+- For a hotfix on `main` (e.g. broken release workflow), branch from `main`, target `QA` in the PR, and the maintainer cherry-picks or merges through normally.
+
+## Local development
+
+See [docs/local-development.md](docs/local-development.md) for the full step-by-step. The short version:
+
+```bash
+git clone https://github.com/JulioMoralesB/free-games-notifier.git
+cd free-games-notifier
+
+# Python backend
+python3 -m venv env && source env/bin/activate
+pip install -r requirements.txt -r requirements-dev.txt
+cp .env.example .env  # set DISCORD_WEBHOOK_URL at minimum
+
+# Dashboard (only if you touch dashboard/)
+cd dashboard && npm install && cd ..
+```
+
+## Running tests
+
+```bash
+# Python — 345 tests across api, scrapers, storage, dedupe, etc.
+pytest tests/ -v -m "not integration and not production"
+
+# Dashboard — Vitest + React Testing Library
+cd dashboard && npm test
+
+# Linter — fails CI if it has anything to say
+ruff check .
+ruff check . --fix   # auto-fix safe issues
+```
+
+CI runs all three on every PR (see `.github/workflows/tests.yml`). Get them green locally before pushing.
+
+## Commit message style
+
+We loosely follow [Conventional Commits](https://www.conventionalcommits.org/). Browse `git log --no-merges` for recent examples; the prefixes in active use are:
+
+| Prefix | Use for |
+|---|---|
+| `feat:` | New user-visible functionality |
+| `fix:` | Bug fixes |
+| `refactor:` | Internal restructuring with no behaviour change |
+| `chore:` | Tooling, dependencies, repo hygiene |
+| `docs:` | Documentation-only changes |
+| `test:` | Adding or fixing tests |
+| `ci:` | GitHub Actions / release pipeline changes |
+
+Scopes (`feat(scrapers): …`) are optional but encouraged for non-trivial PRs.
+
+The body of the commit is more important than the title — explain **why** the change exists, what alternatives you considered, and any caveats. The diff already shows what changed.
+
+## Pull requests
+
+The PR template (auto-filled when you open a PR) asks for a Summary and a Test plan. Keep both honest:
+
+- **Summary** — bullet points of the user-facing change. If the PR is purely internal, say so explicitly.
+- **Test plan** — what you actually ran, not what should theoretically pass. CI will tell us if the tests themselves work.
+
+Always include `Closes #N` in the PR body if the PR resolves an open issue. The GitHub Action that syncs the project board relies on this.
+
+If you opened the issue and started working on it, add the `in-progress` label to the issue when you push the branch (or ask a maintainer to). The label drives the project board column.
+
+## Where things live
+
+A short orientation map. For the full architecture overview, read [docs/architecture.md](docs/architecture.md).
+
+| If you are touching… | Read first |
+|---|---|
+| A scraper (Epic, Steam, …) | `modules/scrapers/`, [docs/architecture.md](docs/architecture.md) |
+| The Discord notification format | `modules/notifier.py`, the `_TRANSLATIONS` table for i18n |
+| The REST API | `api/` package, [docs/api.md](docs/api.md) |
+| The dashboard | `dashboard/src/`, [docs/dashboard.md](docs/dashboard.md) |
+| Database schema | `modules/database.py`, `alembic/versions/`, [docs/database-migrations.md](docs/database-migrations.md) |
+| Configuration / env vars | `config.py`, [docs/configuration.md](docs/configuration.md) |
+| Logging | `modules/logging_config.py` (structured JSON for Loki/Grafana) |
+
+## Logging conventions
+
+- Use a module-level logger: `logger = logging.getLogger(__name__)` — never `logging.info(...)` directly.
+- Use lazy formatting: `logger.info("Found %d games", len(games))` — not f-strings. The format call is skipped when the level is filtered out.
+- Logs are emitted as JSON. Promtail/Loki extract `level`, `service`, and `logger` fields automatically.
+
+## Adding a new scraper
+
+1. Create `modules/scrapers/yourstore.py` with a class that subclasses `Scraper` (in `base.py`).
+2. Implement `store_name` and `fetch_free_games() -> list[FreeGame]`.
+3. Register it in `modules/scrapers/__init__.py` so `get_enabled_scrapers(["yourstore"])` returns it.
+4. Update [docs/configuration.md](docs/configuration.md) and the README's roadmap.
+
+## Adding a new dashboard language
+
+See the [Dashboard Developer Guide](docs/dashboard.md#adding-a-new-language) — TypeScript will report missing translation keys at compile time, and the parity test (`translations.test.ts`) catches runtime drift.
+
+## Releases
+
+Releases are **maintainer-driven**. The flow:
+
+1. PRs are merged into `QA` and accumulate.
+2. Maintainer merges `QA → main` once a coherent set of changes is ready.
+3. Maintainer creates an annotated tag: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+4. The release workflow builds and publishes the image. Self-hosters update via `docker compose pull && docker compose up -d`.
+
+Pre-release tags (`vX.Y.Z-rc.1`) are supported and skip the `:latest` tag automatically — useful for testing the published image before the official release.
+
+## Getting help
+
+If you're stuck, open a draft PR or issue and tag it with `question`. Don't sit on a problem alone — the maintainer is friendly and the codebase isn't huge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Use the issue templates that appear automatically when you click **New Issue**. 
 feature branch ──► QA ──► main ──► tag vX.Y.Z ──► GHCR image
 ```
 
-- All PRs target the **`QA`** branch — never `main` directly. \`QA\` accumulates changes until they are ready for a release; `main` is the source of truth for release tags.
+- All PRs target the **`QA`** branch — never `main` directly. `QA` accumulates changes until they are ready for a release; `main` is the source of truth for release tags.
 - A maintainer fast-forwards `main` from `QA` and tags `vX.Y.Z` to publish a release. Pushing the tag triggers `.github/workflows/release.yml`, which builds the multi-arch Docker image and publishes it to `ghcr.io/juliomoralesb/free-games-notifier`.
 - For a hotfix on `main` (e.g. broken release workflow), branch from `main`, target `QA` in the PR, and the maintainer cherry-picks or merges through normally.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+## Supported versions
+
+Free Games Notifier follows a rolling-release model: only the **latest published GHCR image tag** receives security updates. Older tagged versions are kept available for download but are not patched.
+
+If you are pinning to a specific version (e.g. `ghcr.io/juliomoralesb/free-games-notifier:1.2.3`), please update to the latest tag promptly when a security release is announced.
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.** Public disclosure before a fix is available exposes every self-hoster running the project.
+
+### How to report
+
+Use one of the following private channels:
+
+1. **GitHub Security Advisory** (preferred) — go to the repo's [Security tab](https://github.com/JulioMoralesB/free-games-notifier/security/advisories/new) and click **Report a vulnerability**. This creates a private discussion thread visible only to you and the maintainer.
+2. **Email** — send the details to <juliomoralesbd@gmail.com> with the subject line `[SECURITY] free-games-notifier`.
+
+### What to include
+
+- A clear description of the vulnerability and its potential impact
+- Steps to reproduce, ideally with a minimal proof of concept
+- The version (Git commit SHA or GHCR tag) affected
+- Whether you would like public credit once the advisory is published
+
+### What to expect
+
+| Step | Timeline |
+|---|---|
+| Acknowledgement of receipt | Within **7 days** |
+| Initial assessment + severity classification | Within **14 days** |
+| Patch + coordinated disclosure plan | Depends on severity and complexity, typically 30 days for high-severity issues |
+
+You will be kept in the loop throughout. If the issue turns out to be lower-severity than initially reported (e.g. requires already-compromised credentials), we will explain that reasoning rather than silently downgrade.
+
+## Scope
+
+Issues considered in scope:
+
+- Authentication or authorization bypass on any REST endpoint
+- Server-Side Request Forgery (SSRF) in webhook handling — we already validate Discord webhook URLs in `validate_discord_webhook_url`; bypasses of that validator are in scope
+- SQL injection in the PostgreSQL backend
+- Remote code execution via crafted scraper input or webhook payloads
+- Path traversal in storage / log file handling
+- Leaks of sensitive configuration (API keys, webhook URLs) via logs, error responses, or the dashboard
+- Container escape from the published Docker image
+- Vulnerable third-party dependencies that affect the running service
+
+Issues considered out of scope:
+
+- DoS via local resource exhaustion (we are a single-tenant home-server app)
+- Issues requiring a malicious upstream (Epic Games or Steam returning crafted responses) — please report those to the upstream service
+- Social engineering against the maintainer
+- Reports generated entirely by automated scanners with no manual triage
+
+## Hardening recommendations for self-hosters
+
+The project's defaults are intentionally low-friction for home-server use. If you expose the service to the public internet, **please** apply the following:
+
+- Set `API_KEY` to a strong random value; without it, all mutating endpoints are unauthenticated
+- Put the service behind a reverse proxy with TLS (Caddy, Traefik, Cloudflare Tunnel)
+- Restrict access to `/dashboard/`, `/check`, `/notify/discord/resend`, and `/config` to your home network or an authenticated tunnel; the dashboard reveals game history, the other endpoints can drain Discord rate limits
+- Keep your PostgreSQL instance off the public internet; bind the service to `127.0.0.1` or a private Docker network
+
+A future release (see milestone **Hybrid Configuration**) will surface these recommendations directly in the dashboard and warn when the service is reachable without authentication.
+
+## Credit
+
+We are happy to publicly credit reporters in the GitHub Security Advisory and the release notes. Let us know in your initial report whether you want credit and what name / handle to use.
+
+Thanks for helping keep self-hosters safe.


### PR DESCRIPTION
## Summary

Adds the standard files contributors and security researchers expect to find on a public repo. With this PR landed, the repo is now genuinely \"open for contributions\" — newcomers know how to set up, where to file what, and how to report vulnerabilities responsibly.

| File | Purpose |
|---|---|
| \`CONTRIBUTING.md\` | Dev setup, branch model (\`QA → main → tag\`), Conventional Commits style, test commands, scraper extension guide, release flow |
| \`SECURITY.md\` | Private vulnerability reporting (GitHub Security Advisory + email fallback), 7-day acknowledgement SLA, scope, self-hoster hardening tips |
| \`.github/ISSUE_TEMPLATE/bug_report.md\` | Repro steps + expected/actual + environment (version, deployment, storage backend, region) |
| \`.github/ISSUE_TEMPLATE/feature_request.md\` | Use case, proposed solution, alternatives, willingness to contribute |
| \`.github/ISSUE_TEMPLATE/config.yml\` | Disables blank issues; redirects general questions to Discussions and security reports to private advisories |
| \`.github/PULL_REQUEST_TEMPLATE.md\` | Summary + Test plan + QA-base reminder; pre-fills \`Closes #N\` for project board automation |
| \`CODE_OF_CONDUCT.md\` | Adopts Contributor Covenant 2.1 by reference (avoids stale-copy maintenance); reports go to maintainer email |

## Why reference instead of copying the CoC?

Contributor Covenant 2.1 is the most widely adopted CoC in OSS (Linux kernel, Kubernetes, Rails). Linking to the canonical text means the project automatically benefits from upstream clarifications without needing a PR every time the spec evolves. Reporting flow and maintainer contact are still defined locally.

## Test plan

- [ ] GitHub auto-detects the templates and shows the picker on \"New Issue\"
- [ ] Opening a new PR pre-fills with \`PULL_REQUEST_TEMPLATE.md\` content
- [ ] \"Report a vulnerability\" button appears in the repo's Security tab
- [ ] All cross-references between the new files resolve (CONTRIBUTING ↔ CODE_OF_CONDUCT ↔ SECURITY ↔ docs/\*.md)

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)