### PR TITLE
Make heartbeat push fire-and-forget to prevent service crashes

### DIFF
--- a/modules/healthcheck.py
+++ b/modules/healthcheck.py
@@ -6,20 +6,30 @@ from config import ENABLE_HEALTHCHECK, HEALTHCHECK_URL
 
 logger = logging.getLogger(__name__)
 
-# Sends a hearthbeat to a monitor service like UptimeKuma to ensure that the service is running and healthy
+HEARTBEAT_TIMEOUT = 10  # seconds
+
+# Sends a heartbeat to a monitor service like UptimeKuma so it knows this service is
+# alive. This is fire-and-forget: it must never affect this service's own health,
+# restart behavior, or exit status, so any failure is caught, logged, and swallowed
+# rather than propagated (an uncaught exception here would crash the `schedule`
+# loop in main.py, which has no exception handling of its own, and take the whole
+# process down with it).
 def healthcheck():
     if not ENABLE_HEALTHCHECK:
         logger.debug("Healthcheck is disabled. Skipping healthcheck.")
         return
-    logger.debug(f"Sending request to healthcheck monitor. URL: {HEALTHCHECK_URL}")
-    response = requests.get(HEALTHCHECK_URL)
-    logger.debug(f"Received response from monitor. Status Code: {response.status_code}")
-    response_json = response.json()
-    ok_value = response_json.get("ok")
+    try:
+        logger.debug(f"Sending request to healthcheck monitor. URL: {HEALTHCHECK_URL}")
+        response = requests.get(HEALTHCHECK_URL, timeout=HEARTBEAT_TIMEOUT)
+        logger.debug(f"Received response from monitor. Status Code: {response.status_code}")
+        response_json = response.json()
+        ok_value = response_json.get("ok")
 
-    logger.debug(f"Ok value: {ok_value}")
+        logger.debug(f"Ok value: {ok_value}")
 
-    if response.status_code != 200 or ok_value not in [True, 'true']:
-        logger.error(f"Failed to get response from monitor. Status Code: {response.status_code}")
-        return
-    logger.debug("Obtained 200 status code from monitor response. Service is healthy")
+        if response.status_code != 200 or ok_value not in [True, 'true']:
+            logger.error(f"Failed to get response from monitor. Status Code: {response.status_code}")
+            return
+        logger.debug("Obtained 200 status code from monitor response. Service is healthy")
+    except Exception as e:
+        logger.error(f"Failed to push heartbeat to monitor: {e}")

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,86 @@
+from unittest.mock import MagicMock, patch
+
+import requests as requests_lib
+
+from modules import healthcheck as healthcheck_module
+
+HEALTHCHECK_URL = "https://uptime.example.com/api/push/abc123"
+
+
+def _make_response(status_code=200, ok_value=True):
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json.return_value = {"ok": ok_value}
+    return mock_resp
+
+
+class TestHealthcheckDisabled:
+    def test_does_nothing_when_disabled(self):
+        with patch("modules.healthcheck.ENABLE_HEALTHCHECK", False), \
+             patch("modules.healthcheck.requests.get") as mock_get:
+            healthcheck_module.healthcheck()
+
+        mock_get.assert_not_called()
+
+
+class TestHealthcheckHappyPath:
+    def test_sends_get_request_to_monitor_url(self):
+        with patch("modules.healthcheck.ENABLE_HEALTHCHECK", True), \
+             patch("modules.healthcheck.HEALTHCHECK_URL", HEALTHCHECK_URL), \
+             patch("modules.healthcheck.requests.get") as mock_get:
+            mock_get.return_value = _make_response()
+            healthcheck_module.healthcheck()
+
+        args, kwargs = mock_get.call_args
+        assert args[0] == HEALTHCHECK_URL
+        assert kwargs["timeout"] == healthcheck_module.HEARTBEAT_TIMEOUT
+
+    def test_logs_error_when_status_code_is_not_200(self, caplog):
+        with patch("modules.healthcheck.ENABLE_HEALTHCHECK", True), \
+             patch("modules.healthcheck.HEALTHCHECK_URL", HEALTHCHECK_URL), \
+             patch("modules.healthcheck.requests.get") as mock_get, \
+             caplog.at_level("ERROR"):
+            mock_get.return_value = _make_response(status_code=500)
+            healthcheck_module.healthcheck()
+
+        assert "Failed to get response from monitor" in caplog.text
+
+
+class TestHealthcheckFailuresAreSwallowed:
+    """A failed heartbeat push must never raise: it should be logged and swallowed."""
+
+    def test_connection_error_does_not_raise(self, caplog):
+        with patch("modules.healthcheck.ENABLE_HEALTHCHECK", True), \
+             patch("modules.healthcheck.HEALTHCHECK_URL", HEALTHCHECK_URL), \
+             patch(
+                 "modules.healthcheck.requests.get",
+                 side_effect=requests_lib.exceptions.ConnectionError("monitor unreachable"),
+             ), \
+             caplog.at_level("ERROR"):
+            healthcheck_module.healthcheck()  # must not raise
+
+        assert "Failed to push heartbeat to monitor" in caplog.text
+
+    def test_timeout_does_not_raise(self, caplog):
+        with patch("modules.healthcheck.ENABLE_HEALTHCHECK", True), \
+             patch("modules.healthcheck.HEALTHCHECK_URL", HEALTHCHECK_URL), \
+             patch(
+                 "modules.healthcheck.requests.get",
+                 side_effect=requests_lib.exceptions.Timeout(),
+             ), \
+             caplog.at_level("ERROR"):
+            healthcheck_module.healthcheck()  # must not raise
+
+        assert "Failed to push heartbeat to monitor" in caplog.text
+
+    def test_malformed_json_response_does_not_raise(self, caplog):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.side_effect = ValueError("not JSON")
+        with patch("modules.healthcheck.ENABLE_HEALTHCHECK", True), \
+             patch("modules.healthcheck.HEALTHCHECK_URL", HEALTHCHECK_URL), \
+             patch("modules.healthcheck.requests.get", return_value=mock_resp), \
+             caplog.at_level("ERROR"):
+            healthcheck_module.healthcheck()  # must not raise
+
+        assert "Failed to push heartbeat to monitor" in caplog.text


### PR DESCRIPTION
wrapped the heartbeat request in try/except (logs and swallows any network/HTTP/parsing error) and added a 10s timeout so a hung monitor can't block the scheduler thread. Added tests/test_healthcheck.py covering disabled/happy-path/non-200/connection-error/timeout/malformed-JSON cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Heartbeat requests now time out after 10 seconds, preventing prolonged waits.
  * Healthcheck failures are handled gracefully and logged without disrupting the application.
  * Existing response validation and logging behavior remains intact.

* **Tests**
  * Added coverage for disabled checks, successful requests, error responses, connection failures, timeouts, and malformed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->