### PR TITLE
chore: drop QA from CI pull_request triggers

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
         - main
-        - QA
 
 jobs:
   integration-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-      - QA
 
 jobs:
   # ─── Python: lint + unit tests ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- We're retiring the QA-branch workflow: PRs now target `main` directly instead of promoting through `QA`.
- Removed `QA` from the `pull_request` trigger branches in `tests.yml` and `integration-tests.yml` so CI stops expecting PRs against that branch.

The `QA` branch itself is left in place (inactive), just no longer used for PRs.

## Test plan
- [x] N/A — workflow-trigger-only change, no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)